### PR TITLE
[bugfixes] - Inconsistency between names + others

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ CemrgApp is an MITK based interactive medical imaging application with image pro
 
 License
 -------
-Copyright (c) Cardiac Electromechanics Research Group. All rights reserved.
-CemrgApp is available as free open-source software under a 3-clause BSD license.
-This software is distributed WITHOUT ANY WARRANTY or SUPPORT.
+Copyright (c) Cardiac Electromechanics Research Group. All rights reserved.\
+CemrgApp is available as free open-source software under a 3-clause BSD license.\
+This software is distributed WITHOUT ANY WARRANTY or SUPPORT.\
 This software SHOULD NOT be used for diagnosis or treatment of patients.
 
 Current Versions
@@ -19,7 +19,7 @@ Refer to Wiki pages at https://github.com/CemrgAppDevelopers/CemrgApp/wiki
 
 Citation
 --------
-Please cite the following article, if you use CemrgApp in your project:
+Please cite the following article, if you use CemrgApp in your project:\
 Razeghi O, Solís-Lemus J, Lee A et al. CemrgApp: An interactive medical imaging application with image processing, computer vision, and machine learning toolkits for cardiovascular research. SoftwareX. 2020;12:100570. doi:10.1016/j.softx.2020.100570
 
 Contacts

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ Instructions
 ------------
 Refer to Wiki pages at https://github.com/CemrgAppDevelopers/CemrgApp/wiki
 
+Citation
+--------
+Please cite the following article, if you use CemrgApp in your project:
+Razeghi O, Solís-Lemus J, Lee A et al. CemrgApp: An interactive medical imaging application with image processing, computer vision, and machine learning toolkits for cardiovascular research. SoftwareX. 2020;12:100570. doi:10.1016/j.softx.2020.100570
+
 Contacts
 --------
 - http://www.cemrgapp.com/

--- a/Version2.0/Applications/MainApp/CemrgApp.cpp
+++ b/Version2.0/Applications/MainApp/CemrgApp.cpp
@@ -25,7 +25,7 @@ int main(int argc, char** argv) {
 
     mitk::BaseApplication myApp(argc, argv);
     myApp.setSingleMode(true);
-    myApp.setApplicationName("CemrgApp v2.0");
+    myApp.setApplicationName("CemrgApp v2.1");
     myApp.setOrganizationName("KCL");
 
     // -------------------------------------------------------------------

--- a/Version2.0/Modules/CemrgAppModule/cmdapps/CMakeLists.txt
+++ b/Version2.0/Modules/CemrgAppModule/cmdapps/CMakeLists.txt
@@ -3,6 +3,7 @@ option(BUILD_CEMRG_FIXSHELL "Build fixing shell values command line app. " ON)
 option(BUILD_CEMRG_CLIPPINGTOOL "Build clipping valve command line app. " ON)
 option(BUILD_CEMRG_PROJECTLGE "Build lge projection command line app. " ON)
 option(BUILD_CEMRG_IM2INR "Build image to inr command line app. " ON)
+option(BUILD_CEMRG_VENTRICLE_SEGMENTATION_RELABEL "Build ventricle segmentation relabelling command line app" ON)
 
 if(BUILD_CemrgCMDApps)
   mitkFunctionCreateCommandLineApp(
@@ -41,5 +42,13 @@ if(BUILD_CEMRG_IM2INR)
     NAME CemrgIM2INR
     DEPENDS MitkCemrgAppModule
     CPP_FILES CemrgIM2INR.cpp
+  )
+endif()
+
+if(BUILD_CEMRG_VENTRICLE_SEGMENTATION_RELABEL)
+  mitkFunctionCreateCommandLineApp(
+    NAME CemrgVentricleSegmRelabel
+    DEPENDS MitkCemrgAppModule
+    CPP_FILES CemrgVentricleSegmRelabel.cpp
   )
 endif()

--- a/Version2.0/Modules/CemrgAppModule/cmdapps/CemrgResampleReorient.cpp
+++ b/Version2.0/Modules/CemrgAppModule/cmdapps/CemrgResampleReorient.cpp
@@ -1,0 +1,165 @@
+/*=========================================================================
+
+Program:   Medical Imaging & Interaction Toolkit
+Language:  C++
+Date:      $Date$
+Version:   $Revision$
+
+Copyright (c) German Cancer Research Center, Division of Medical and
+Biological Informatics. All rights reserved.
+See MITKCopyright.txt or http://www.mitk.org/copyright.html for details.
+
+This software is distributed WITHOUT ANY WARRANTY; without even
+the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+/*=========================================================================
+CEMRG CMD APP TEMPLATE
+This app serves as a template for the command line apps to be implemented
+in the framework.
+=========================================================================*/
+
+// Qmitk
+#include <mitkIOUtil.h>
+#include <mitkSurface.h>
+#include <mitkImageCast.h>
+#include <mitkITKImageImport.h>
+#include <mitkCommandLineParser.h>
+#include <mitkImagePixelReadAccessor.h>
+
+// VTK
+#include <vtkClipPolyData.h>
+#include <vtkImplicitBoolean.h>
+#include <vtkPlane.h>
+#include <vtkSphere.h>
+#include <vtkDataSetSurfaceFilter.h>
+#include <vtkPolyDataConnectivityFilter.h>
+#include <vtkCleanPolyData.h>
+#include <vtkMath.h>
+#include <vtkFloatArray.h>
+#include <vtkPolyData.h>
+#include <vtkCellData.h>
+#include <vtkPolyDataNormals.h>
+#include <vtkIdList.h>
+
+// ITK
+#include <itkPoint.h>
+#include <itkResampleImageFilter.h>
+#include <itkImageRegionIterator.h>
+#include <itkGrayscaleErodeImageFilter.h>
+#include <itkImageRegionIteratorWithIndex.h>
+#include <itkBinaryBallStructuringElement.h>
+#include <itkNearestNeighborInterpolateImageFunction.h>
+#include <itkImageFileWriter.h>
+
+// Qt
+#include <QtDebug>
+#include <QString>
+#include <QFileInfo>
+#include <QProcess>
+#include <QMessageBox>
+#include <numeric>
+
+#include <CemrgScar3D.h>
+#include <CemrgCommandLine.h>
+#include <CemrgCommonUtils.h>
+
+#include <algorithm>
+#include <string>
+
+int main(int argc, char* argv[]) {
+    mitkCommandLineParser parser;
+
+    // Set general information about your command-line app
+    parser.setCategory("Pre processing");
+    parser.setTitle("Resample/Reorient Command-line App");
+    parser.setContributor("CEMRG, KCL");
+    parser.setDescription("Resample and reorient nifti files.");
+
+    // How should arguments be prefixed
+    parser.setArgumentPrefix("--", "-");
+
+    // Add arguments. Unless specified otherwise, each argument is optional.
+    parser.addArgument(
+                "input", "i", mitkCommandLineParser::InputFile,
+                "NIFTI file path", "Full path of .nii file.",
+                us::Any(), false);
+    parser.addArgument(
+                "output", "o", mitkCommandLineParser::OutputFile,
+                "Output file", "Where to save the output.",
+                us::Any(), false);
+    parser.addArgument( // optional
+                "reorient", "r", mitkCommandLineParser::Bool,
+                "Reorient to RAI", "Whether the nifti should be reoriented to RAI configuration (default=true)");
+    parser.addArgument( // optional
+                "verbose", "v", mitkCommandLineParser::Bool,
+                "Verbose Output", "Whether to produce verbose output (default=false)");
+
+    // Parse arguments.
+    // This method returns a mapping of long argument names to their values.
+    auto parsedArgs = parser.parseArguments(argc, argv);
+
+    if (parsedArgs.empty()){
+        return EXIT_FAILURE;
+    }
+
+    if (parsedArgs["input"].Empty() || parsedArgs["output"].Empty() ) {
+        MITK_INFO << parser.helpText();
+        return EXIT_FAILURE;
+    }
+
+    // Parse, cast and set required arguments
+    auto inFilename = us::any_cast<std::string>(parsedArgs["input"]);
+    auto outFilename = us::any_cast<std::string>(parsedArgs["output"]);
+
+    // Default values for optional arguments
+    auto verbose = false;
+    auto reorientToRAI = true;
+
+    // Parse, cast and set optional arguments
+    if (parsedArgs.end() != parsedArgs.find("verbose")) {
+        verbose = us::any_cast<bool>(parsedArgs["verbose"]);
+    }
+    if (parsedArgs.end() != parsedArgs.find("reorient")) {
+        reorientToRAI = us::any_cast<bool>(parsedArgs["reorient"]);
+    }
+
+    try{
+        // Code the functionality of the cmd app here.
+        MITK_INFO(verbose) << "Verbose mode ON.";
+
+        // PARSING ARGUMENTS
+        QString inputName = QString::fromStdString(inFilename);
+        QString outname = QString::fromStdString(outFilename);
+
+        if (!outname.contains(".nii", Qt::CaseSensitive)){
+            outname = outname + ".nii";
+        }
+
+        MITK_INFO(verbose) << "Obtaining input file path and working directory: ";
+
+        // OBTAINING directory and image path variables
+        QFileInfo fi(inputName);
+        QString direct = fi.absolutePath();
+        QString imagePath = fi.absoluteFilePath();
+
+        MITK_INFO << "Resampling image to isometric.";
+        MITK_INFO(verbose && reorientToRAI) << "Reorienting image to RAI.";
+        mitk::Image::Pointer image = CemrgCommonUtils::IsoImageResampling(imagePath, reorientToRAI);
+        MITK_INFO << "Saving...";
+        mitk::IOUtil::Save(image, imagePath.toStdString());
+
+        MITK_INFO(verbose) << "Goodbye!";
+    }
+    catch (const std::exception &e) {
+        MITK_ERROR << e.what();
+        return EXIT_FAILURE;
+    }
+    catch(...) {
+        MITK_ERROR << "Unexpected error";
+        return EXIT_FAILURE;
+    }
+
+
+}

--- a/Version2.0/Modules/CemrgAppModule/cmdapps/CemrgVentricleSegmRelabel.cpp
+++ b/Version2.0/Modules/CemrgAppModule/cmdapps/CemrgVentricleSegmRelabel.cpp
@@ -1,0 +1,384 @@
+/*=========================================================================
+
+Program:   Medical Imaging & Interaction Toolkit
+Language:  C++
+Date:      $Date$
+Version:   $Revision$
+
+Copyright (c) German Cancer Research Center, Division of Medical and
+Biological Informatics. All rights reserved.
+See MITKCopyright.txt or http://www.mitk.org/copyright.html for details.
+
+This software is distributed WITHOUT ANY WARRANTY; without even
+the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+/*=========================================================================
+CEMRG CMD APP TEMPLATE
+This app serves as a template for the command line apps to be implemented
+in the framework.
+=========================================================================*/
+
+// Qmitk
+#include <mitkIOUtil.h>
+#include <mitkSurface.h>
+#include <mitkImage.h>
+#include <mitkImageCast.h>
+#include <mitkITKImageImport.h>
+#include <mitkCommandLineParser.h>
+#include <mitkImagePixelReadAccessor.h>
+
+// VTK
+#include <vtkImplicitBoolean.h>
+#include <vtkImplicitVolume.h>
+#include <vtkImplicitDataSet.h>
+#include <vtkClipPolyData.h>
+#include <vtkCleanPolyData.h>
+#include <vtkImplicitPolyDataDistance.h>
+#include <vtkPlane.h>
+#include <vtkSphere.h>
+#include <vtkDataSetSurfaceFilter.h>
+#include <vtkPolyDataConnectivityFilter.h>
+#include <vtkMath.h>
+#include <vtkFloatArray.h>
+#include <vtkPolyData.h>
+#include <vtkPointData.h>
+#include <vtkCellData.h>
+#include <vtkPolyDataNormals.h>
+#include <vtkIdList.h>
+#include <vtkPolyDataConnectivityFilter.h>
+#include <vtkDataSetSurfaceFilter.h>
+
+// ITK
+#include <itkPoint.h>
+#include <itkImage.h>
+#include <itkImageFileWriter.h>
+#include <itkResampleImageFilter.h>
+#include <itkImageRegionIterator.h>
+#include <itkThresholdImageFilter.h>
+#include <itkBinaryThresholdImageFilter.h>
+#include <itkBinaryDilateImageFilter.h>
+#include <itkMultiplyImageFilter.h>
+#include <itkImageRegionIteratorWithIndex.h>
+#include <itkBinaryBallStructuringElement.h>
+#include <itkNearestNeighborInterpolateImageFunction.h>
+#include <itkImageRegionIterator.h>
+
+// Qt
+#include <QtDebug>
+#include <QString>
+#include <QFileInfo>
+#include <QProcess>
+#include <QMessageBox>
+#include <numeric>
+
+#include <CemrgScar3D.h>
+#include <CemrgCommandLine.h>
+
+#include <algorithm>
+#include <string>
+
+typedef itk::Image<uint8_t,3> ImageType;
+typedef itk::ResampleImageFilter<ImageType, ImageType> ResampleImageFilterType;
+typedef itk::NearestNeighborInterpolateImageFunction<ImageType> NNInterpolatorType;
+typedef itk::BinaryThresholdImageFilter<ImageType, ImageType> ThresholdType;
+typedef itk::BinaryBallStructuringElement<ImageType::PixelType, 3> StrElType;
+typedef itk::BinaryDilateImageFilter<ImageType, ImageType, StrElType> ImFilterType;
+typedef itk::MultiplyImageFilter<ImageType, ImageType, ImageType> ImMultiplyType;
+typedef itk::ImageRegionIterator<ImageType> IteratorType;
+
+// ResampleImageFilterType::Pointer & imresize(ImageType::Pointer imToResize, ImageType::Pointer imTarget);
+ThresholdType::Pointer thresholdImage(ImageType::Pointer input, uint8_t thresholdVal, QString debugPrefix, bool debugging);
+ImFilterType::Pointer imdilate(ImageType::Pointer input, uint8_t radius, QString debugPrefix, bool debugging);
+ImMultiplyType::Pointer immultiply(ImageType::Pointer input1, ImageType::Pointer input2, QString debugPrefix, bool debugging);
+void relabel(ImageType::Pointer & imageToRelabel, ImageType::Pointer imageFragment, uint8_t fromLabel, uint8_t toLabel);
+
+int main(int argc, char* argv[]) {
+    mitkCommandLineParser parser;
+
+    // Set general information about your command-line app
+    parser.setCategory("EASI processing");
+    parser.setTitle("Labelled image re-labelling Command-line App");
+    parser.setContributor("CEMRG, KCL");
+    parser.setDescription("Relabel segmentation (RV/LV) for Fibres.");
+
+    // How should arguments be prefixed
+    parser.setArgumentPrefix("--", "-");
+
+    // Add arguments. Unless specified otherwise, each argument is optional.
+    // See mitkCommandLineParser::addArgument() for more information.
+    // parser.addArgument(
+    //   "input-path", "p", mitkCommandLineParser::InputFile,
+    //   "Input Directory Path", "Path of directory containing LGE files.",
+    //   us::Any(), false);
+    parser.addArgument(
+                "input", "i", mitkCommandLineParser::InputFile,
+                "Input image segmentation", "Full path of segmentation file.",
+                us::Any(), false);
+    parser.addArgument(
+                "bloodpool", "b", mitkCommandLineParser::InputFile,
+                "Input image bloodpool seg", "Full path of bloodpool file.",
+                us::Any(), false);
+    parser.addArgument( // optional
+                "bp-rv", "rv", mitkCommandLineParser::String,
+                "Bloodpool segmentation label (RV)", "RV segmentation label (default=30)");
+    parser.addArgument( // optional
+                "bp-lv", "lv", mitkCommandLineParser::String,
+                "Bloodpool segmentation label (LV)", "LV segmentation label (default=10)");
+    parser.addArgument( // optional
+                "swap-labels", "sl", mitkCommandLineParser::String,
+                "Swap levels code", "Code to swap labels (syntax: 'N,M' , default:1,5)");
+    parser.addArgument(// optional
+                "output", "o", mitkCommandLineParser::String,
+                "Output file name", "Where to save the output (default: output.nii).");
+    parser.addArgument( // optional
+                "debug", "d", mitkCommandLineParser::Bool,
+                "Debug Outputs", "Save intermediate steps of processing.");
+    parser.addArgument( // optional
+                "verbose", "v", mitkCommandLineParser::Bool,
+                "Verbose Output", "Whether to produce verbose output");
+
+    // Parse arguments.
+    // This method returns a mapping of long argument names to their values.
+    auto parsedArgs = parser.parseArguments(argc, argv);
+
+    if (parsedArgs.empty())
+        return EXIT_FAILURE;
+
+    if (parsedArgs["input"].Empty() || parsedArgs["bloodpool"].Empty()) {
+        MITK_INFO << parser.helpText();
+        return EXIT_FAILURE;
+    }
+
+    // Parse, cast and set required arguments
+    auto inFilename = us::any_cast<std::string>(parsedArgs["input"]);
+    auto bloodFilename = us::any_cast<std::string>(parsedArgs["bloodpool"]);
+    // auto outFilename = us::any_cast<std::string>(parsedArgs["output"]);
+
+    // Default values for optional arguments
+    auto verbose = false;
+    auto debug = false;
+    std::string bp_rv = "30";
+    std::string bp_lv = "10";
+    std::string swaplabels = "1,5";
+    std::string outFilename = "output.nii";
+
+    // Parse, cast and set optional arguments
+    if (parsedArgs.end() != parsedArgs.find("verbose")){
+        verbose = us::any_cast<bool>(parsedArgs["verbose"]);
+    }
+
+    if (parsedArgs.end() != parsedArgs.find("bp-rv")){
+        bp_rv = us::any_cast<std::string>(parsedArgs["bp-rv"]);
+    }
+
+    if (parsedArgs.end() != parsedArgs.find("bp-lv")){
+        bp_lv = us::any_cast<std::string>(parsedArgs["bp-lv"]);
+    }
+
+    if (parsedArgs.end() != parsedArgs.find("swap-labels")){
+        swaplabels  = us::any_cast<std::string>(parsedArgs["swap-labels"]);
+    }
+
+    if (parsedArgs.end() != parsedArgs.find("output")){
+        outFilename = us::any_cast<std::string>(parsedArgs["output"]);
+    }
+
+    if (parsedArgs.end() != parsedArgs.find("debug")){
+        debug = us::any_cast<bool>(parsedArgs["debug"]);
+    }
+
+
+    try{
+        // Code the functionality of the cmd app here.
+        MITK_INFO(verbose) << "Verbose mode ON.";
+
+        // PARSING ARGUMENTS
+        QString inname = QString::fromStdString(inFilename);
+        QString bloodpname = QString::fromStdString(bloodFilename);
+        QString outname = QString::fromStdString(outFilename);
+
+        if (!outname.contains(".nii", Qt::CaseSensitive))
+            outname = outname + ".nii";
+
+        MITK_INFO(verbose) << "Obtaining input file path and working directory: ";
+
+        // OBTAINING directory and inputPath variables
+        QFileInfo fi(inname);
+        QFileInfo bpfi(bloodpname);
+
+        QString path = fi.absolutePath() + mitk::IOUtil::GetDirectorySeparator();
+        QString inputPath = fi.absoluteFilePath();
+        QString bpPath = bpfi.absoluteFilePath();
+        QString outputPath = path + outname;
+        QString debugPrefix = path + "DEBUG_";
+
+        mitk::Point3D origin;
+
+        MITK_INFO << ("INPUT SEGMENTATION: " + inputPath).toStdString();
+        MITK_INFO << ("OUTPUT: " + outputPath).toStdString();
+        MITK_INFO(debug) << ("DEBUG PREFIX: " + debugPrefix).toStdString();
+
+        MITK_INFO(verbose) << "Loading Image.";
+        mitk::Image::Pointer image = mitk::IOUtil::Load<mitk::Image>(inputPath.toStdString());
+        mitk::Image::Pointer bp = mitk::IOUtil::Load<mitk::Image>(bpPath.toStdString());
+
+        if(image && bp){
+
+            MITK_INFO << "Resize bloodpool to image size";
+            ImageType::Pointer itkInput = ImageType::New();
+            ImageType::Pointer itkBp = ImageType::New();
+
+            mitk::CastToItkImage(image, itkInput);
+            mitk::CastToItkImage(bp, itkBp);
+
+            ResampleImageFilterType::Pointer resampler = ResampleImageFilterType::New();
+            NNInterpolatorType::Pointer nninterp = NNInterpolatorType::New();
+
+            resampler->SetInput(itkBp);
+            resampler->SetInterpolator(nninterp);
+            resampler->SetOutputOrigin(itkInput->GetOrigin());
+            ImageType::SizeType input_size = itkInput->GetLargestPossibleRegion().GetSize();
+            ImageType::SpacingType input_spacing = itkInput->GetSpacing();
+
+            resampler->SetSize(input_size);
+            resampler->SetOutputSpacing(input_spacing);
+            resampler->SetOutputDirection(itkInput->GetDirection());
+            resampler->UpdateLargestPossibleRegion();
+
+            if(debug){
+                QString step1 = debugPrefix + "S1_resizedBloodPool.nii";
+                mitk::IOUtil::Save(mitk::ImportItkImage(resampler->GetOutput()), step1.toStdString());
+            }
+
+            MITK_INFO << "Select left ventricle with bloodpool-label";
+            // threshold
+            uint8_t bpLeftV = uint8_t(std::stoi(bp_lv));
+            QString step2 = debugPrefix + "S2-1_thresholdedLV.nii";
+            ThresholdType::Pointer thresLV = thresholdImage(resampler->GetOutput(), bpLeftV, step2, debug);
+
+            MITK_INFO << "Select right ventricle with bloodpool-label";
+            // threshold
+            uint8_t bpRightV = uint8_t(std::stoi(bp_rv));
+            step2 = debugPrefix + "S2-2_thresholdedRV.nii";
+            ThresholdType::Pointer thresRV = thresholdImage(resampler->GetOutput(), bpRightV, step2, debug);
+
+            MITK_INFO << "Dilating selected blooodpool.";
+            // Image dilation on thresholded image
+            QString step3 = debugPrefix + "S3_dilatedRV.nii";
+            ImFilterType::Pointer dilateFilter = imdilate(thresRV->GetOutput(), 1.0, step3, debug);
+
+            MITK_INFO << "Extracting bloodpool from input image";
+            // Multiply input image to thresholed bloodpool (imageFragment)
+            QString step4 = debugPrefix + "S4-1_extractedSegmentLV.nii";
+            ImMultiplyType::Pointer imMultLV = immultiply(itkInput, thresLV->GetOutput(), step4, debug);
+
+            step4 = debugPrefix + "S4-2_extractedSegmentRV.nii";
+            ImMultiplyType::Pointer imMultRV = immultiply(itkInput, dilateFilter->GetOutput(), step4, debug);
+
+            MITK_INFO << "Relabel specific volume in original.";
+            QString swapLabelsStr = QString::fromStdString(swaplabels);
+            QStringList swapLabelsList = swapLabelsStr.split(QLatin1Char(','));
+
+            uint8_t fromLabel = uint8_t(swapLabelsList.at(0).toInt());
+            uint8_t toLabel = uint8_t(swapLabelsList.at(1).toInt());
+
+            relabel(itkInput, imMultLV->GetOutput(), toLabel, fromLabel);
+            relabel(itkInput, imMultRV->GetOutput(), fromLabel, toLabel);
+
+            mitk::IOUtil::Save(mitk::ImportItkImage(itkInput), outputPath.toStdString());
+
+        }
+
+        MITK_INFO(verbose) << "Goodbye!";
+    }
+    catch (const std::exception &e) {
+        MITK_ERROR << e.what();
+        return EXIT_FAILURE;
+    }
+    catch(...) {
+        MITK_ERROR << "Unexpected error";
+        return EXIT_FAILURE;
+    }
+
+}
+
+ThresholdType::Pointer thresholdImage(ImageType::Pointer input, uint8_t thresholdVal, QString debugOutput, bool debugging){
+    ThresholdType::Pointer thresholdOutput = ThresholdType::New();
+    thresholdOutput->SetInput(input);
+    thresholdOutput->SetLowerThreshold(thresholdVal);
+    thresholdOutput->SetUpperThreshold(thresholdVal);
+    thresholdOutput->SetInsideValue(1);
+    thresholdOutput->SetOutsideValue(0);
+    thresholdOutput->Update();
+
+    if(debugging){
+        mitk::IOUtil::Save(mitk::ImportItkImage(thresholdOutput->GetOutput()), debugOutput.toStdString());
+    }
+
+    return thresholdOutput;
+}
+
+ImFilterType::Pointer imdilate(ImageType::Pointer input, uint8_t radius, QString debugOutput,  bool debugging){
+    StrElType structuringElement;
+    structuringElement.SetRadius(static_cast<unsigned long>(radius));
+    structuringElement.CreateStructuringElement();
+
+    ImFilterType::Pointer imDilateFilter = ImFilterType::New();
+    imDilateFilter->SetInput(input);
+    imDilateFilter->SetKernel(structuringElement);
+    imDilateFilter->SetDilateValue(1); // same as threshold's insideValue
+
+    if(debugging){
+        mitk::IOUtil::Save(mitk::ImportItkImage(imDilateFilter->GetOutput()), debugOutput.toStdString());
+    }
+
+    return imDilateFilter;
+}
+
+ImMultiplyType::Pointer immultiply(ImageType::Pointer input1, ImageType::Pointer input2, QString debugOutput, bool debugging){
+    ImMultiplyType::Pointer imMultiplication = ImMultiplyType::New();
+    imMultiplication->SetInput1(input1);
+    imMultiplication->SetInput2(input2);
+
+    if (debugging){
+        mitk::IOUtil::Save(mitk::ImportItkImage(imMultiplication->GetOutput()), debugOutput.toStdString());
+    }
+
+    return imMultiplication;
+}
+
+void relabel(ImageType::Pointer & imageToRelabel, ImageType::Pointer imageFragment, uint8_t fromLabel, uint8_t toLabel){
+    IteratorType relabelIter(imageToRelabel, imageToRelabel->GetLargestPossibleRegion());
+    IteratorType condIter(imageFragment, imageFragment->GetLargestPossibleRegion());
+
+    while(!relabelIter.IsAtEnd()){
+        if(condIter.Get() == fromLabel){ //label LV=1, change for RV=5
+            relabelIter.Set(toLabel);
+        }
+        ++relabelIter;
+        ++condIter;
+    }
+}
+
+// ResampleImageFilterType::Pointer & imresize(ImageType::Pointer imToResize, ImageType::Pointer imTarget){
+//     ResampleImageFilterType::Pointer resampler = ResampleImageFilterType::New();
+//     NNInterpolatorType::Pointer nninterp = NNInterpolatorType::New();
+//
+//     resampler->SetInput(imToResize);
+//     resampler->SetInterpolator(nninterp);
+//     resampler->SetOutputOrigin(imTarget->GetOrigin());
+//     ImageType::SizeType input_size = imTarget->GetLargestPossibleRegion().GetSize();
+//     ImageType::SpacingType input_spacing = imTarget->GetSpacing();
+//
+//     resampler->SetSize(input_size);
+//     resampler->SetOutputSpacing(input_spacing);
+//     resampler->SetOutputDirection(imTarget->GetDirection());
+//     resampler->UpdateLargestPossibleRegion();
+//
+//     if(debug){
+//         QString step1 = debugPrefix + "S1_resizedBloodPool.nii";
+//         mitk::IOUtil::Save(mitk::ImportItkImage(resampler->GetOutput()), step1.toStdString());
+//     }
+// }

--- a/Version2.0/Modules/CemrgAppModule/include/CemrgAtriaClipper.h
+++ b/Version2.0/Modules/CemrgAppModule/include/CemrgAtriaClipper.h
@@ -97,8 +97,9 @@ private:
     double clSpacing = 2.000; //Resample the centerline with this spacing
     double radiusAdj = 2.000; //Adjustment for cutter planes radii
 
+    //Centrelines variables
     bool ctrlnOrientation;
-    bool manualCtrLnOrient;
+    bool manualCtrLnOrient = false;
 
     //Cutters properties
     std::vector<int> manuals; //Cutter's tilt manual or automatic

--- a/Version2.0/Modules/CemrgAppModule/include/CemrgAtriaClipper.h
+++ b/Version2.0/Modules/CemrgAppModule/include/CemrgAtriaClipper.h
@@ -56,16 +56,18 @@ public:
     void CalcParamsOfPlane(vtkSmartPointer<vtkRegularPolygonSource> plane, int ctrLineNo, int position);
     void ResetCtrLinesClippingPlanes();
 
-    mitk::Image::Pointer GetClippedSegImage() const;
-    mitk::Surface::Pointer GetClippedSurface() const;
-    std::vector<vtkSmartPointer<vtkvmtkPolyDataCenterlines>> GetCentreLines() const;
-    std::vector<vtkSmartPointer<vtkRegularPolygonSource>> GetCentreLinePolyPlanes() const;
-    std::vector<std::vector<double>> GetMClipperAngles();
-    std::vector<int> GetManualType() const;
-    void SetToAutomaticClipperMode(int clippersIndex);
+    inline mitk::Image::Pointer GetClippedSegImage() const{return clippedSegImage;};
+    inline mitk::Surface::Pointer GetClippedSurface() const{return clippedSurface;};
+    inline std::vector<vtkSmartPointer<vtkvmtkPolyDataCenterlines>> GetCentreLines() const{return centreLines;};
+    inline std::vector<vtkSmartPointer<vtkRegularPolygonSource>> GetCentreLinePolyPlanes() const{return centreLinePolyPlanes;};
+    inline std::vector<std::vector<double>> GetMClipperAngles(){return normalPlAngles;};
+    inline std::vector<int> GetManualType() const{return manuals;};
+
+    inline void SetToAutomaticClipperMode(int clippersIndex){manuals[clippersIndex] = 0;};
+    inline void SetRadiusAdjustment(double value){radiusAdj = value;};
+
     void SetMClipperAngles(double* value, int clippersIndex);
     void SetMClipperSeeds(vtkSmartPointer<vtkPolyData> pickedCutterSeeds, int clippersIndex);
-    void SetRadiusAdjustment(double value);
 
 private:
 

--- a/Version2.0/Modules/CemrgAppModule/include/CemrgAtriaClipper.h
+++ b/Version2.0/Modules/CemrgAppModule/include/CemrgAtriaClipper.h
@@ -49,8 +49,8 @@ public:
 
     CemrgAtriaClipper(QString directory, mitk::Surface::Pointer surface);
 
-    void ComputeCtrLines(std::vector<int> pickedSeedLabels, vtkSmartPointer<vtkIdList> pickedSeedIds, bool flip);
-    void ComputeCtrLinesClippers(std::vector<int> pickedSeedLabels);
+    bool ComputeCtrLines(std::vector<int> pickedSeedLabels, vtkSmartPointer<vtkIdList> pickedSeedIds, bool flip);
+    bool ComputeCtrLinesClippers(std::vector<int> pickedSeedLabels);
     void ClipVeinsMesh(std::vector<int> pickedSeedLabels);
     void ClipVeinsImage(std::vector<int> pickedSeedLabels, mitk::Image::Pointer segImage, bool morphAnalysis);
     void CalcParamsOfPlane(vtkSmartPointer<vtkRegularPolygonSource> plane, int ctrLineNo, int position);

--- a/Version2.0/Modules/CemrgAppModule/include/CemrgAtriaClipper.h
+++ b/Version2.0/Modules/CemrgAppModule/include/CemrgAtriaClipper.h
@@ -66,6 +66,13 @@ public:
     inline void SetToAutomaticClipperMode(int clippersIndex){manuals[clippersIndex] = 0;};
     inline void SetRadiusAdjustment(double value){radiusAdj = value;};
 
+    // getter for orientation boolean - add to plugin (view)
+    inline bool GetCentreLinesOrientation(){return ctrlnOrientation;};
+    inline bool IsManualCentrelines(){return manualCtrLnOrient;};
+    inline void ManualCentreLineOrientation(bool clo){ctrlnOrientation=clo; manualCtrLnOrient = true;};
+    inline void SetManualCentreLineOrientationOn(){ManualCentreLineOrientation(true);};
+    inline void SetManualCentreLineOrientationOff(){ManualCentreLineOrientation(false);};
+
     void SetMClipperAngles(double* value, int clippersIndex);
     void SetMClipperSeeds(vtkSmartPointer<vtkPolyData> pickedCutterSeeds, int clippersIndex);
 
@@ -89,6 +96,9 @@ private:
     double criterion = 0.025; //Ostium if slope higher than highslope and above bump criterion
     double clSpacing = 2.000; //Resample the centerline with this spacing
     double radiusAdj = 2.000; //Adjustment for cutter planes radii
+
+    bool ctrlnOrientation;
+    bool manualCtrLnOrient;
 
     //Cutters properties
     std::vector<int> manuals; //Cutter's tilt manual or automatic

--- a/Version2.0/Modules/CemrgAppModule/include/CemrgCommandLine.h
+++ b/Version2.0/Modules/CemrgAppModule/include/CemrgCommandLine.h
@@ -66,6 +66,7 @@ public:
 
     //Execute Docker Specific Functions
     QString DockerCemrgNetPrediction(QString mra);
+    QString DockerDicom2Nifti(QString path2dicomfolder);
 
     //Docker Helper Functions
     void SetUseDockerContainers(bool dockerContainersOnOff);

--- a/Version2.0/Modules/CemrgAppModule/include/CemrgCommonUtils.h
+++ b/Version2.0/Modules/CemrgAppModule/include/CemrgCommonUtils.h
@@ -50,6 +50,8 @@ public:
 
     //Sampling Utils
     static mitk::Image::Pointer Downsample(mitk::Image::Pointer image, int factor);
+    static mitk::Image::Pointer IsoImageResampling(mitk::Image::Pointer image, bool reorientToRAI=true);
+    static mitk::Image::Pointer IsoImageResampling(QString imPath, bool reorientToRAI=true);
 
     //Mesh Utils
     static mitk::Surface::Pointer LoadVTKMesh(std::string path);

--- a/Version2.0/Modules/CemrgAppModule/include/CemrgCommonUtils.h
+++ b/Version2.0/Modules/CemrgAppModule/include/CemrgCommonUtils.h
@@ -34,6 +34,7 @@ PURPOSE.  See the above copyright notices for more information.
 #include <mitkBoundingObject.h>
 #include <mitkDataNode.h>
 #include <mitkDataStorage.h>
+#include <QString>
 
 class MITKCEMRGAPPMODULE_EXPORT CemrgCommonUtils {
 
@@ -55,7 +56,8 @@ public:
 
     //Mesh Utils
     static mitk::Surface::Pointer LoadVTKMesh(std::string path);
-    static QString m3dlibParamFileGenerator(QString dir, QString filename="param-template.par", QString thicknessCalc="0");
+    static QString M3dlibParamFileGenerator(QString dir, QString filename="param-template.par", QString thicknessCalc="0");
+    static void ConvertToCarto(std::string vtkPath);
 
     //Generic
     static mitk::DataNode::Pointer AddToStorage(

--- a/Version2.0/Modules/CemrgAppModule/include/CemrgCommonUtils.h
+++ b/Version2.0/Modules/CemrgAppModule/include/CemrgCommonUtils.h
@@ -54,13 +54,16 @@ public:
     static mitk::Image::Pointer IsoImageResampleReorient(mitk::Image::Pointer image, bool resample=true, bool reorientToRAI=true);
     static mitk::Image::Pointer IsoImageResampleReorient(QString imPath, bool resample=true, bool reorientToRAI=true);
 
-    // convert2nifti
+    //Nifti Conversion Utils
     static bool ConvertToNifti(mitk::BaseData::Pointer oneNode, QString path2file, bool resample=false, bool reorient=false);
 
     //Mesh Utils
     static mitk::Surface::Pointer LoadVTKMesh(std::string path);
     static QString M3dlibParamFileGenerator(QString dir, QString filename="param-template.par", QString thicknessCalc="0");
     static void ConvertToCarto(std::string vtkPath);
+
+    //Tracking Utils
+    static void MotionTrackingReport(QString directory, int timePoints);
 
     //Generic
     static mitk::DataNode::Pointer AddToStorage(

--- a/Version2.0/Modules/CemrgAppModule/include/CemrgCommonUtils.h
+++ b/Version2.0/Modules/CemrgAppModule/include/CemrgCommonUtils.h
@@ -60,7 +60,7 @@ public:
     //Mesh Utils
     static mitk::Surface::Pointer LoadVTKMesh(std::string path);
     static QString M3dlibParamFileGenerator(QString dir, QString filename="param-template.par", QString thicknessCalc="0");
-    static void ConvertToCarto(std::string vtkPath);
+    static void ConvertToCarto(std::string vtkPath, std::vector<double>, double, double, int, bool);
     static void CalculatePolyDataNormals(vtkSmartPointer<vtkPolyData>& pd, bool celldata=true);
 
     //Tracking Utils
@@ -68,7 +68,7 @@ public:
 
     //Generic
     static mitk::DataNode::Pointer AddToStorage(
-            mitk::BaseData* data, std::string nodeName, mitk::DataStorage::Pointer ds);
+            mitk::BaseData* data, std::string nodeName, mitk::DataStorage::Pointer ds, bool init=true);
 
 private:
 

--- a/Version2.0/Modules/CemrgAppModule/include/CemrgCommonUtils.h
+++ b/Version2.0/Modules/CemrgAppModule/include/CemrgCommonUtils.h
@@ -51,8 +51,11 @@ public:
 
     //Sampling Utils
     static mitk::Image::Pointer Downsample(mitk::Image::Pointer image, int factor);
-    static mitk::Image::Pointer IsoImageResampling(mitk::Image::Pointer image, bool reorientToRAI=true);
-    static mitk::Image::Pointer IsoImageResampling(QString imPath, bool reorientToRAI=true);
+    static mitk::Image::Pointer IsoImageResampleReorient(mitk::Image::Pointer image, bool resample=true, bool reorientToRAI=true);
+    static mitk::Image::Pointer IsoImageResampleReorient(QString imPath, bool resample=true, bool reorientToRAI=true);
+
+    // convert2nifti
+    static bool ConvertToNifti(mitk::BaseData::Pointer oneNode, QString path2file, bool resample=false, bool reorient=false);
 
     //Mesh Utils
     static mitk::Surface::Pointer LoadVTKMesh(std::string path);

--- a/Version2.0/Modules/CemrgAppModule/include/CemrgCommonUtils.h
+++ b/Version2.0/Modules/CemrgAppModule/include/CemrgCommonUtils.h
@@ -51,8 +51,8 @@ public:
 
     //Sampling Utils
     static mitk::Image::Pointer Downsample(mitk::Image::Pointer image, int factor);
-    static mitk::Image::Pointer IsoImageResampleReorient(mitk::Image::Pointer image, bool resample=true, bool reorientToRAI=true);
-    static mitk::Image::Pointer IsoImageResampleReorient(QString imPath, bool resample=true, bool reorientToRAI=true);
+    static mitk::Image::Pointer IsoImageResampleReorient(mitk::Image::Pointer image, bool resample=false, bool reorientToRAI=false);
+    static mitk::Image::Pointer IsoImageResampleReorient(QString imPath, bool resample=false, bool reorientToRAI=false);
 
     //Nifti Conversion Utils
     static bool ConvertToNifti(mitk::BaseData::Pointer oneNode, QString path2file, bool resample=false, bool reorient=false);
@@ -61,6 +61,7 @@ public:
     static mitk::Surface::Pointer LoadVTKMesh(std::string path);
     static QString M3dlibParamFileGenerator(QString dir, QString filename="param-template.par", QString thicknessCalc="0");
     static void ConvertToCarto(std::string vtkPath);
+    static void CalculatePolyDataNormals(vtkSmartPointer<vtkPolyData>& pd, bool celldata=true);
 
     //Tracking Utils
     static void MotionTrackingReport(QString directory, int timePoints);

--- a/Version2.0/Modules/CemrgAppModule/include/CemrgScarAdvanced.h
+++ b/Version2.0/Modules/CemrgAppModule/include/CemrgScarAdvanced.h
@@ -111,6 +111,7 @@ public:
     double fandi3_postSurfacePercentage;
     double fandi3_preScarScore;
     double fandi3_postScarScore;
+    std::string fandi1_fname, fandi2_fname, fandi3_fname;
 
     std::vector<std::pair<int, int> > _visited_point_list; // stores the neighbours around a point
     std::vector<vtkSmartPointer<vtkPolyData> > _paths; // container to store shortest paths between points
@@ -157,17 +158,28 @@ public:
     inline void SetLeftRightPrefix(std::string lrpre){_leftrightpre = lrpre;};
     inline void SetOutputPrefix(std::string prefixname){_prefix = _leftrightpre + prefixname;};
 
+    inline void SetSurfaceAreaFilename(std::string fn1){fandi1_fname = fn1;};
+    inline void SetGapsFilename(std::string fn2){fandi2_fname = fn2;};
+    inline void SetComparisonFilename(std::string fn3){fandi3_fname = fn3;};
+
+    inline std::string GetOutputPath(){return _outPath;};
+    inline std::string GetSurfaceAreaFilename(){return fandi1_fname;};
+    inline std::string GetGapsFilename(){return fandi2_fname;};
+    inline std::string GetComparisonFilename(){return fandi3_fname;};
+    inline std::string GetPrefix() {return (_leftrightpre + _prefix);};
+    inline std::string PathAndPrefix() {return (GetOutputPath()+ GetPrefix());};
+
+    inline bool isPointIDArrayEmpty() {return (_pointidarray.empty());};
+
     inline void ClearLeftRightPrefix(){_leftrightpre = "";};
 
     void ResetValues();
 
     // Helper functions
+    void SaveStrToFile(std::string path2file, std::string filename, std::string text);
     void PushBackOnPointIDArray(int pointID);
-    bool isPointIDArrayEmpty();
     std::string ThresholdedShell(double thresho);
     std::string ScarOverlap(vtkSmartPointer<vtkPolyData> prepd, double prethresh, vtkSmartPointer<vtkPolyData> postpd, double posttresh);
-    std::string PathAndPrefix();
-    std::string GetPrefix();
     std::vector<vtkSmartPointer<vtkActor> > GetPathsMappersAndActors();
     std::string PrintAblationGapsResults(double mean, double stdv, double val);
     std::string PrintThresholdResults(double mean, double stdv, double val);

--- a/Version2.0/Modules/CemrgAppModule/include/CemrgScarAdvanced.h
+++ b/Version2.0/Modules/CemrgAppModule/include/CemrgScarAdvanced.h
@@ -89,6 +89,8 @@ class MITKCEMRGAPPMODULE_EXPORT CemrgScarAdvanced {
 
 public:
 
+    bool _debugScarAdvanced;
+
     int _neighbourhood_size;
     int _run_count;
     double _fill_threshold;
@@ -127,24 +129,36 @@ public:
     std::vector<int> _corridoridarray;
 
     // Getters and setters
-    bool IsWeighted();
-    bool PreScoresExist();
-    bool PostScoresExist();
-    void SetWeightedCorridorBool(bool isw);
-    void SetInputData(vtkSmartPointer<vtkPolyData> mesh);
-    void SetNeighbourhoodSize(int s);
-    void SetFillThreshold(double s);
-    void SetMaxScalar(double s);
-    void SetOutputFileName(std::string filename);
-    void SetOutputPrefix(std::string prefixname);
-    void SetLeftRightPrefix(std::string lrpre);
-    void ClearLeftRightPrefix();
+    inline bool IsDebug(){return _debugScarAdvanced;};
+
+    inline bool IsWeighted() {return _weightedcorridor;};
+    inline bool PreScoresExist(){return (fandi3_preSurfacePercentage>=0 && fandi3_preScarScore>=0);};
+    inline bool PostScoresExist(){return (fandi3_postSurfacePercentage>=0 && fandi3_postScarScore>=0);};
+    inline int GetThresholdValue(){return _fill_threshold;};
+    inline vtkSmartPointer<vtkPolyData> GetSourcePolyData(){return _SourcePolyData;};
+
     QString GetOutputSufix();
-    void SetOutputPath(std::string pathname);
-    void GetConnectedVertices(
-            vtkSmartPointer<vtkPolyData> mesh, int seed, vtkSmartPointer<vtkIdList> connectedVertices);
-    vtkSmartPointer<vtkPolyData> GetSourcePolyData();
-    int GetThresholdValue();
+    void GetConnectedVertices(vtkSmartPointer<vtkPolyData> mesh, int seed, vtkSmartPointer<vtkIdList> connectedVertices);
+
+    inline void SetDebug(bool db){_debugScarAdvanced = db;};
+    inline void SetDebugOn(){SetDebug(true);};
+    inline void SetDebugOff(){SetDebug(false);};
+
+    inline void SetWeightedCorridorBool(bool isw){_weightedcorridor = isw;};
+    inline void SetWeightedCorridorOn(){SetWeightedCorridorBool(true);};
+    inline void SetWeightedCorridorOff(){SetWeightedCorridorBool(false);};
+
+    inline void SetNeighbourhoodSize(int s){_neighbourhood_size = s;};
+    inline void SetFillThreshold(double s){_fill_threshold = s;};
+    inline void SetMaxScalar(double s){_max_scalar = s;};
+    inline void SetInputData(vtkSmartPointer<vtkPolyData> inputmesh){_SourcePolyData->DeepCopy(inputmesh);};
+    inline void SetOutputFileName(std::string filename){_fileOutName = filename;};
+    inline void SetOutputPath(std::string pathname){_outPath = pathname;};
+    inline void SetLeftRightPrefix(std::string lrpre){_leftrightpre = lrpre;};
+    inline void SetOutputPrefix(std::string prefixname){_prefix = _leftrightpre + prefixname;};
+
+    inline void ClearLeftRightPrefix(){_leftrightpre = "";};
+
     void ResetValues();
 
     // Helper functions

--- a/Version2.0/Modules/CemrgAppModule/src/CemrgAtriaClipper.cpp
+++ b/Version2.0/Modules/CemrgAppModule/src/CemrgAtriaClipper.cpp
@@ -81,9 +81,7 @@ CemrgAtriaClipper::CemrgAtriaClipper(QString directory, mitk::Surface::Pointer s
     this->surface = surface;
     this->clippedSurface = surface;
     this->clippedSegImage = mitk::Image::New();
-
     ctrlnOrientation = false;
-    manualCtrLnOrient = false;
 }
 
 bool CemrgAtriaClipper::ComputeCtrLines(std::vector<int> pickedSeedLabels, vtkSmartPointer<vtkIdList> pickedSeedIds, bool flip) {
@@ -623,11 +621,10 @@ vtkIdType CemrgAtriaClipper::CentreOfMass(mitk::Surface::Pointer surface) {
     //Polydata of surface
     vtkSmartPointer<vtkPolyData> pd = surface->GetVtkPolyData();
     CemrgCommonUtils::CalculatePolyDataNormals(pd, false);
-
     vtkSmartPointer<vtkFloatArray> pdNormals = vtkFloatArray::SafeDownCast(pd->GetPointData()->GetNormals());
     vtkSmartPointer<vtkCenterOfMass> centre = vtkSmartPointer<vtkCenterOfMass>::New();
-    double centreInSurface[3];
 
+    double centreInSurface[3];
     centre->SetInputData(pd);
     centre->SetUseScalarsAsWeights(false);
     centre->Update();
@@ -636,24 +633,23 @@ vtkIdType CemrgAtriaClipper::CentreOfMass(mitk::Surface::Pointer surface) {
     vtkSmartPointer<vtkPointLocator> pointLocator = vtkSmartPointer<vtkPointLocator>::New();
     pointLocator->SetDataSet(pd);
     pointLocator->BuildLocator();
-
     vtkIdType id = pointLocator->FindClosestPoint(centreInSurface); // output of method
 
     double * pointNormal = pdNormals->GetTuple(id);
     double * pointInSurface = pd->GetPoints()->GetPoint(id);
-
     double xProduct = 0;
     double mitralValvePlane[3] = {0}; //change name
     mitralValvePlane[0] = pointInSurface[0] - centreInSurface[0];
     mitralValvePlane[1] = pointInSurface[1] - centreInSurface[1];
     mitralValvePlane[2] = pointInSurface[2] - centreInSurface[2];
-    for (int i = 0; i < 3; i++){
+    for (int i = 0; i < 3; i++) {
         xProduct += (mitralValvePlane[i])*(pointNormal[i]);
-    }
+    }//_for
 
-    if(xProduct < 0){ // orientation of centrelines
+    //Orientation of centrelines
+    if (xProduct < 0) {
         ctrlnOrientation = true;
-    }
+    }//_if
 
     return id;
 }

--- a/Version2.0/Modules/CemrgAppModule/src/CemrgAtriaClipper.cpp
+++ b/Version2.0/Modules/CemrgAppModule/src/CemrgAtriaClipper.cpp
@@ -590,10 +590,14 @@ void CemrgAtriaClipper::CalcParamsOfPlane(vtkSmartPointer<vtkRegularPolygonSourc
     double clipRadius = radii->GetValue(position) * radiusAdj;
 
     //Normal calculations
-    double x_s = 0, y_s = 0, z_s = 0;
-    x_s = line->GetPoint(position+1)[0] - line->GetPoint(position)[0];
-    y_s = line->GetPoint(position+1)[1] - line->GetPoint(position)[1];
-    z_s = line->GetPoint(position+1)[2] - line->GetPoint(position)[2];
+    double x_s = 0.0, y_s = 0.0, z_s = 0.0;
+    double pointAtPosition[3], pointAtNextPosition[3];
+    line->GetPoint(position+1, pointAtNextPosition);
+    line->GetPoint(position, pointAtPosition);
+
+    x_s = pointAtNextPosition[0] - pointAtPosition[0];
+    y_s = pointAtNextPosition[1] - pointAtPosition[1];
+    z_s = pointAtNextPosition[2] - pointAtPosition[2];
     if (manuals[ctrLineNo] == 1) {
         double x, y, z;
         double lng = sqrt(pow(x_s,2) + pow(y_s,2) + pow(z_s,2));

--- a/Version2.0/Modules/CemrgAppModule/src/CemrgAtriaClipper.cpp
+++ b/Version2.0/Modules/CemrgAppModule/src/CemrgAtriaClipper.cpp
@@ -89,6 +89,7 @@ CemrgAtriaClipper::CemrgAtriaClipper(QString directory, mitk::Surface::Pointer s
 bool CemrgAtriaClipper::ComputeCtrLines(std::vector<int> pickedSeedLabels, vtkSmartPointer<vtkIdList> pickedSeedIds, bool flip) {
 
     try {
+
 		MITK_INFO << "Producibility test. ";
         QString prodPath = directory + mitk::IOUtil::GetDirectorySeparator();
         mitk::IOUtil::Save(surface, (prodPath + "prodLineSurface.vtk").toStdString());
@@ -108,6 +109,7 @@ bool CemrgAtriaClipper::ComputeCtrLines(std::vector<int> pickedSeedLabels, vtkSm
         prodFile3.close();
 
         if (centreLines.size() == 0) {
+
             //Prepare source and target seeds
             vtkSmartPointer<vtkIdList> inletSeedIds = vtkSmartPointer<vtkIdList>::New();
             vtkSmartPointer<vtkIdList> outletSeedIds = vtkSmartPointer<vtkIdList>::New();
@@ -115,10 +117,8 @@ bool CemrgAtriaClipper::ComputeCtrLines(std::vector<int> pickedSeedLabels, vtkSm
             MITK_INFO << "Determining centre lines' orientation.";
             vtkIdType centreOfMassId = CentreOfMass(surface);
             inletSeedIds->InsertNextId(centreOfMassId);
-
             MITK_INFO << "Number of pickedSeedLabels: ";
             MITK_INFO << pickedSeedLabels.size();
-
             MITK_INFO(manualCtrLnOrient) << "Centre lines orientation set manually.";
             MITK_INFO(!manualCtrLnOrient) << "Centre lines orientation set automatically.";
 
@@ -148,21 +148,14 @@ bool CemrgAtriaClipper::ComputeCtrLines(std::vector<int> pickedSeedLabels, vtkSm
                 label->SetName("PickedSeedLabels");
                 label->InsertNextValue(pickedSeedLabels.at(i));
                 centreLineFilter->GetOutput()->GetFieldData()->AddArray(label);
-
                 centreLines.push_back(centreLineFilter);
-                mitk::ProgressBar::GetInstance()->Progress();
+
             }//_for
-        } else{
-            mitk::ProgressBar::GetInstance()->Progress(pickedSeedLabels.size());
-        }
+        }//_if
 
     } catch(...) {
-
-        mitk::ProgressBar::GetInstance()->Progress(pickedSeedLabels.size());
         return false;
-
     }//_try
-
     return true;
 }
 
@@ -221,19 +214,14 @@ bool CemrgAtriaClipper::ComputeCtrLinesClippers(std::vector<int> pickedSeedLabel
             CalcParamsOfPlane(polygonSource, i, clipPointID);
             polygonSource->Update();
             centreLinePolyPlanes.push_back(polygonSource);
-            mitk::ProgressBar::GetInstance()->Progress();
 
             //Fill in manual cutter
             centreLinePointPlanes.push_back(vtkSmartPointer<vtkPoints>::New());
         }//_for
 
     } catch(...) {
-
-        mitk::ProgressBar::GetInstance()->Progress(pickedSeedLabels.size());
         return false;
-
     }//_try
-
     return true;
 }
 
@@ -276,8 +264,8 @@ void CemrgAtriaClipper::ClipVeinsMesh(std::vector<int> pickedSeedLabels) {
             cleaner->SetInputConnection(lrgRegion->GetOutputPort());
             cleaner->Update();
             clippedSurface->SetVtkPolyData(cleaner->GetOutput());
+
         }//_if
-        mitk::ProgressBar::GetInstance()->Progress();
     }//_for
 
     //Save clipped mesh
@@ -511,9 +499,8 @@ void CemrgAtriaClipper::ClipVeinsImage(std::vector<int> pickedSeedLabels, mitk::
         lblShpKpNObjImgFltr->SetNumberOfObjects(1);
         lblShpKpNObjImgFltr->SetAttribute(LabelShapeKeepNObjImgFilterType::LabelObjectType::NUMBER_OF_PIXELS);
         lblShpKpNObjImgFltr->Update();
-
         segItkImage = lblShpKpNObjImgFltr->GetOutput();
-        mitk::ProgressBar::GetInstance()->Progress();
+
     }//_for
 
     //Label individual veins
@@ -570,6 +557,7 @@ void CemrgAtriaClipper::ClipVeinsImage(std::vector<int> pickedSeedLabels, mitk::
         path = directory + mitk::IOUtil::GetDirectorySeparator() + "AnalyticBloodpool.nii";
         mitk::IOUtil::Save(pvLabelled, path.toStdString());
     }//_if
+
     //Save clipped image
     path = directory + mitk::IOUtil::GetDirectorySeparator() + "PVeinsCroppedImage.nii";
     mitk::Image::Pointer pvCropped = mitk::ImportItkImage(segItkImage)->Clone();

--- a/Version2.0/Modules/CemrgAppModule/src/CemrgAtriaClipper.cpp
+++ b/Version2.0/Modules/CemrgAppModule/src/CemrgAtriaClipper.cpp
@@ -82,7 +82,7 @@ CemrgAtriaClipper::CemrgAtriaClipper(QString directory, mitk::Surface::Pointer s
 bool CemrgAtriaClipper::ComputeCtrLines(std::vector<int> pickedSeedLabels, vtkSmartPointer<vtkIdList> pickedSeedIds, bool flip) {
 
     try {
-
+		MITK_INFO << "Producibility test. ";
         QString prodPath = directory + mitk::IOUtil::GetDirectorySeparator();
         mitk::IOUtil::Save(surface, (prodPath + "prodLineSurface.vtk").toStdString());
         ofstream prodFile1;
@@ -644,41 +644,6 @@ void CemrgAtriaClipper::VTKWriter(vtkSmartPointer<vtkPolyData> PD, QString path)
     writer->Write();
 }
 
-mitk::Image::Pointer CemrgAtriaClipper::GetClippedSegImage() const {
-
-    return clippedSegImage;
-}
-
-mitk::Surface::Pointer CemrgAtriaClipper::GetClippedSurface() const {
-
-    return clippedSurface;
-}
-
-std::vector<vtkSmartPointer<vtkvmtkPolyDataCenterlines>> CemrgAtriaClipper::GetCentreLines() const {
-
-    return centreLines;
-}
-
-std::vector<vtkSmartPointer<vtkRegularPolygonSource>> CemrgAtriaClipper::GetCentreLinePolyPlanes() const {
-
-    return centreLinePolyPlanes;
-}
-
-std::vector<int> CemrgAtriaClipper::GetManualType() const {
-
-    return manuals;
-}
-
-std::vector<std::vector<double>> CemrgAtriaClipper::GetMClipperAngles() {
-
-    return normalPlAngles;
-}
-
-void CemrgAtriaClipper::SetToAutomaticClipperMode(int clippersIndex) {
-
-    manuals[clippersIndex] = 0;
-}
-
 void CemrgAtriaClipper::SetMClipperAngles(double* value, int clippersIndex) {
 
     manuals[clippersIndex] = 1;
@@ -690,9 +655,4 @@ void CemrgAtriaClipper::SetMClipperSeeds(vtkSmartPointer<vtkPolyData> pickedCutt
 
     manuals[clippersIndex] = 2;
     centreLinePointPlanes.at(clippersIndex) = pickedCutterSeeds->GetPoints();
-}
-
-void CemrgAtriaClipper::SetRadiusAdjustment(double value) {
-
-    radiusAdj = value;
 }

--- a/Version2.0/Modules/CemrgAppModule/src/CemrgCommandLine.cpp
+++ b/Version2.0/Modules/CemrgAppModule/src/CemrgCommandLine.cpp
@@ -1029,6 +1029,46 @@ QString CemrgCommandLine::DockerCemrgNetPrediction(QString mra) {
     return res;
 }
 
+QString CemrgCommandLine::DockerDicom2Nifti(QString path2dicomfolder){
+    MITK_INFO << "[ATTENTION] Attempting alternative DICOM to NIFTI conversion.";
+
+    QDir dicomhome(path2dicomfolder);
+    QString outAbsolutePath = "ERROR_IN_PROCESSING";
+    QString executablePath = "";
+    QString outPath;
+    bool successful = false;
+
+    MITK_INFO << ("[...] OUTPUT IMAGE: " + outAbsolutePath).toStdString();
+
+    if (_useDockerContainers) {
+        MITK_INFO << "Using docker containers.";
+#if defined(__APPLE__)
+        executablePath = "/usr/local/bin/";
+#endif
+        outPath = dicomhome.absolutePath() + mitk::IOUtil::GetDirectorySeparator() + "NIIs";
+        QString executableName = executablePath+"docker";
+
+        QStringList arguments;
+
+        arguments << "run" << "--rm"  << "--volume="+dicomhome.absolutePath()+":/Data";
+        arguments << "orodrazeghi/dicom-converter" << ".";
+        arguments << "--gantry" << "--inconsistent";
+
+        successful = ExecuteCommand(executableName, arguments, outPath);
+
+    } else {
+        MITK_WARN << "Docker must be running for this feature to be used.";
+    }
+
+    if (successful) {
+        MITK_INFO << "Conversion successful.";
+        outAbsolutePath = outPath;
+    } else{
+        MITK_WARN << "Error with DICOM2NIFTI Docker container.";
+    }
+    return outAbsolutePath;
+}
+
 /***************************************************************************
  *********************** Docker Helper Functions ***************************
  ***************************************************************************/
@@ -1144,8 +1184,9 @@ bool CemrgCommandLine::ExecuteCommand(QString executableName, QStringList argume
     }
     mitk::ProgressBar::GetInstance()->Progress();
 
-    if (processStarted)
+    if (processStarted){
         successful = IsOutputSuccessful(outputPath);
+    }
     return successful;
 }
 

--- a/Version2.0/Modules/CemrgAppModule/src/CemrgCommandLine.cpp
+++ b/Version2.0/Modules/CemrgAppModule/src/CemrgCommandLine.cpp
@@ -102,6 +102,7 @@ QString CemrgCommandLine::ExecuteSurf(QString dir, QString segPath, QString morp
     mitk::ProgressBar::GetInstance()->Progress();
     if (QString::compare(closeOutputPath, "ERROR_IN_PROCESSING")!=0) {
 
+        ExecuteTouch(dir + mitk::IOUtil::GetDirectorySeparator() + "segmentation.vtk");
         surfOutputPath = ExecuteExtractSurface(dir, closeOutputPath, "segmentation.vtk", th, blur);
         mitk::ProgressBar::GetInstance()->Progress();
 

--- a/Version2.0/Modules/CemrgAppModule/src/CemrgCommandLine.cpp
+++ b/Version2.0/Modules/CemrgAppModule/src/CemrgCommandLine.cpp
@@ -94,16 +94,28 @@ QDialog* CemrgCommandLine::GetDialog() {
 QString CemrgCommandLine::ExecuteSurf(QString dir, QString segPath, QString morphOperation, int iter, float th, int blur, int smth) {
 
     MITK_INFO << "[ATTENTION] SURFACE CREATION: Close -> Surface -> Smooth";
+
     QString closeOutputPath, surfOutputPath;
     QString outAbsolutePath = "ERROR_IN_PROCESSING";
-
     closeOutputPath = ExecuteMorphologicalOperation(morphOperation, dir, segPath, "segmentation.s.nii", iter);
+
+    mitk::ProgressBar::GetInstance()->Progress();
     if (QString::compare(closeOutputPath, "ERROR_IN_PROCESSING")!=0) {
+
         surfOutputPath = ExecuteExtractSurface(dir, closeOutputPath, "segmentation.vtk", th, blur);
+        mitk::ProgressBar::GetInstance()->Progress();
+
         if (QString::compare(surfOutputPath, "ERROR_IN_PROCESSING")!=0) {
+
             outAbsolutePath = ExecuteSmoothSurface(dir, surfOutputPath, surfOutputPath, smth);
             remove((dir + mitk::IOUtil::GetDirectorySeparator() + "segmentation.s.nii").toStdString().c_str());
-        }
+            mitk::ProgressBar::GetInstance()->Progress();
+
+        } else {
+            mitk::ProgressBar::GetInstance()->Progress();
+        }//_if
+    } else {
+        mitk::ProgressBar::GetInstance()->Progress(2);
     }//_if
 
     return outAbsolutePath;
@@ -123,24 +135,22 @@ QString CemrgCommandLine::ExecuteCreateCGALMesh(QString dir, QString outputName,
     QString executablePath = "";
     QString executableName;
     QDir meshtools3dhome(dir);
-
     QString outAbsolutePath, outputDirectory, segmentationDirectory;
     QStringList arguments;
-
     segmentationDirectory = dir + mitk::IOUtil::GetDirectorySeparator();
     outputDirectory = segmentationDirectory + "CGALMeshDir";
     outAbsolutePath = outputDirectory + mitk::IOUtil::GetDirectorySeparator() + outputName;
     outAbsolutePath += ".vtk"; // many outputs are created with meshtools3d. .vtk is the one used in CemrgApp
 
     if (_useDockerContainers) {
+
         MITK_INFO << "Using docker containers.";
 #if defined(__APPLE__)
         executablePath = "/usr/local/bin/";
 #endif
-
         executableName = executablePath+"docker";
-        arguments = GetDockerArguments(meshtools3dhome.absolutePath());
 
+        arguments = GetDockerArguments(meshtools3dhome.absolutePath());
         arguments << "-f" << meshtools3dhome.relativeFilePath(paramsFullPath);
         arguments << "-seg_dir" << meshtools3dhome.relativeFilePath(segmentationDirectory);;
         arguments << "-seg_name" << segmentationName;
@@ -156,22 +166,21 @@ QString CemrgCommandLine::ExecuteCreateCGALMesh(QString dir, QString outputName,
                 mitk::IOUtil::GetDirectorySeparator() + QString("CemrgApp") +
                 mitk::IOUtil::GetDirectorySeparator() + QString("M3DLib");
 #endif
-
         executableName = executablePath + mitk::IOUtil::GetDirectorySeparator() + "meshtools3d";
         QDir apathd(executablePath);
-        if (apathd.exists()) {
-            process->setWorkingDirectory(executablePath);
 
+        if (apathd.exists()) {
+
+            process->setWorkingDirectory(executablePath);
             arguments << "-f" << paramsFullPath;
             arguments << "-seg_dir" << segmentationDirectory;;
             arguments << "-seg_name" << segmentationName;
             arguments << "-out_dir" << outputDirectory;
             arguments << "-out_name" << outputName;
 
-        } else {
+        } else {            
             QMessageBox::warning(NULL, "Please check the LOG", "MESHTOOLS3D libraries not found");
-            MITK_WARN << "MESHTOOLS3D libraries not found. Please make sure the M3DLib folder is inside the directory:\n\t"+
-                         mitk::IOUtil::GetProgramPath();
+            MITK_WARN << "MESHTOOLS3D libraries not found. Please make sure the M3DLib folder is inside the directory:\n\t" + mitk::IOUtil::GetProgramPath();
         }//_if
     }
 
@@ -181,24 +190,28 @@ QString CemrgCommandLine::ExecuteCreateCGALMesh(QString dir, QString outputName,
     env.insert("TBB_NUM_THREADS","12");
     process->setProcessEnvironment(env);
 #endif
+
     bool successful = ExecuteCommand(executableName, arguments, outAbsolutePath);
 
-    if (!revertDockerImage.isEmpty()) { // revert to original docker image (in case the object is used later).
+    //Revert to original docker image (in case the object is used later)
+    if (!revertDockerImage.isEmpty())
         SetDockerImage(revertDockerImage);
-    }
 
     if (!successful) {
         if (!_useDockerContainers) {
+
             MITK_WARN << "MESHTOOLS3D did not produce a good outcome. Trying with the MESHTOOLS3D Docker container.";
             SetUseDockerContainersOn();
             return ExecuteCreateCGALMesh(dir, outputName, paramsFullPath, segmentationName);
+
         } else {
+
             MITK_WARN << "MESHTOOLS3D Docker container did not produce a good outcome.";
             return "ERROR_IN_PROCESSING";
-        }
-    } else {
+
+        }//_if_containers
+    } else
         return outAbsolutePath;
-    }
 }
 
 void CemrgCommandLine::ExecuteTracking(QString dir, QString imgTimes, QString param, QString output) {
@@ -291,21 +304,22 @@ void CemrgCommandLine::ExecuteApplying(QString dir, QString inputMesh, double in
     QString output = dir + mitk::IOUtil::GetDirectorySeparator() + "transformed-";
     QString thisOutput;
     for (int i=0; i<noFrames; i++) {
-        thisOutput = output+QString::number(i)+".vtk";
+        thisOutput = output + QString::number(i)+".vtk";
         ExecuteTransformationOnPoints(dir, inputMesh, thisOutput, dofin, iniTime);
         iniTime += fctTime;
+        mitk::ProgressBar::GetInstance()->Progress();
     }
 }
 
 void CemrgCommandLine::ExecuteRegistration(QString dir, QString fixed, QString moving, QString transformFileName, QString modelname) {
 
     MITK_INFO << "[ATTENTION] Attempting Registration.";
+
     //lge : fixed   ||   mra : moving
     QString executablePath = "";
     QString executableName;
     QString commandName = "register";
     QDir mirtkhome(dir);
-
     QString fixedfullpath, movingfullpath, outAbsolutePath;
     QString prodPath = dir + mitk::IOUtil::GetDirectorySeparator();
     QStringList arguments;
@@ -328,10 +342,9 @@ void CemrgCommandLine::ExecuteRegistration(QString dir, QString fixed, QString m
 #if defined(__APPLE__)
         executablePath = "/usr/local/bin/";
 #endif
-
         executableName = executablePath+"docker";
-        arguments = GetDockerArguments(mirtkhome.absolutePath(), commandName);
 
+        arguments = GetDockerArguments(mirtkhome.absolutePath(), commandName);
         arguments << mirtkhome.relativeFilePath(movingfullpath); // input1
         arguments << mirtkhome.relativeFilePath(fixedfullpath); // input2
         arguments << "-dofout" << mirtkhome.relativeFilePath(outAbsolutePath);
@@ -348,12 +361,12 @@ void CemrgCommandLine::ExecuteRegistration(QString dir, QString fixed, QString m
                 mitk::IOUtil::GetDirectorySeparator() + QString("CemrgApp") +
                 mitk::IOUtil::GetDirectorySeparator() + QString("MLib");
 #endif
-
-        executableName = executablePath + mitk::IOUtil::GetDirectorySeparator() + commandName;
+        executableName = executablePath + mitk::IOUtil::GetDirectorySeparator() + commandName;                
         QDir apathd(executablePath);
-        if (apathd.exists()) {
-            process->setWorkingDirectory(executablePath);
 
+        if (apathd.exists()) {
+
+            process->setWorkingDirectory(executablePath);
             arguments << movingfullpath;
             arguments << fixedfullpath;
             arguments << "-dofout" << outAbsolutePath;
@@ -362,10 +375,9 @@ void CemrgCommandLine::ExecuteRegistration(QString dir, QString fixed, QString m
 
         } else {
             QMessageBox::warning(NULL, "Please check the LOG", "MIRTK libraries not found");
-            MITK_WARN << "MIRTK libraries not found. Please make sure the MLib folder is inside the directory;\n\t"+
-                         mitk::IOUtil::GetProgramPath();
+            MITK_WARN << "MIRTK libraries not found. Please make sure the MLib folder is inside the directory;\n\t"+mitk::IOUtil::GetProgramPath();
         }//_if
-    }
+    }//_if
 
     MITK_INFO << ("Performing a " + modelname + " registration").toStdString();
     bool successful = ExecuteCommand(executableName, arguments, outAbsolutePath);
@@ -377,8 +389,8 @@ void CemrgCommandLine::ExecuteRegistration(QString dir, QString fixed, QString m
             ExecuteRegistration(dir, fixed, moving, transformFileName, modelname);
         } else {
             MITK_WARN << "Local MIRTK libraries did not produce a good outcome.";
-        }
-    }
+        }//_if
+    }//_if
 }
 
 void CemrgCommandLine::ExecuteTransformation(QString dir, QString imgname, QString regname, QString transformFileFullPath) {
@@ -389,7 +401,6 @@ void CemrgCommandLine::ExecuteTransformation(QString dir, QString imgname, QStri
     QString executableName;
     QString commandName = "transform-image";
     QDir mirtkhome(dir);
-
     QString dofpath, imgNamefullpath, outAbsolutePath;
     QString prodPath = dir + mitk::IOUtil::GetDirectorySeparator();
     QStringList arguments;
@@ -408,10 +419,9 @@ void CemrgCommandLine::ExecuteTransformation(QString dir, QString imgname, QStri
 #if defined(__APPLE__)
         executablePath = "/usr/local/bin/";
 #endif
-
         executableName = executablePath+"docker";
-        arguments = GetDockerArguments(mirtkhome.absolutePath(), commandName);
 
+        arguments = GetDockerArguments(mirtkhome.absolutePath(), commandName);
         arguments << mirtkhome.relativeFilePath(imgNamefullpath); //input
         arguments << mirtkhome.relativeFilePath(outAbsolutePath); //output
         arguments << "-dof" << mirtkhome.relativeFilePath(dofpath);
@@ -426,12 +436,12 @@ void CemrgCommandLine::ExecuteTransformation(QString dir, QString imgname, QStri
                 mitk::IOUtil::GetDirectorySeparator() + QString("CemrgApp") +
                 mitk::IOUtil::GetDirectorySeparator() + QString("MLib");
 #endif
-
         executableName = executablePath + mitk::IOUtil::GetDirectorySeparator() + commandName;
         QDir apathd(executablePath);
-        if (apathd.exists()) {
-            process->setWorkingDirectory(executablePath);
 
+        if (apathd.exists()) {
+
+            process->setWorkingDirectory(executablePath);
             arguments << imgNamefullpath; //input
             arguments << outAbsolutePath; //output
             arguments << "-dof" << dofpath;
@@ -439,10 +449,9 @@ void CemrgCommandLine::ExecuteTransformation(QString dir, QString imgname, QStri
 
         } else {
             QMessageBox::warning(NULL, "Please check the LOG", "MIRTK libraries not found");
-            MITK_WARN << "MIRTK libraries not found. Please make sure the MLib folder is inside the directory;\n\t"+
-                         mitk::IOUtil::GetProgramPath();
+            MITK_WARN << "MIRTK libraries not found. Please make sure the MLib folder is inside the directory;\n\t"+mitk::IOUtil::GetProgramPath();
         }//_if
-    }
+    }//_if
 
     bool successful = ExecuteCommand(executableName, arguments, outAbsolutePath);
 
@@ -453,8 +462,8 @@ void CemrgCommandLine::ExecuteTransformation(QString dir, QString imgname, QStri
             ExecuteTransformation(dir, imgname, regname, transformFileFullPath);
         } else {
             MITK_WARN << "Local MIRTK libraries did not produce a good outcome.";
-        }
-    }
+        }//_if
+    }//_if
 }
 
 void CemrgCommandLine::ExecuteSimpleTranslation(QString dir, QString sourceMeshP, QString targetMeshP, QString transformFileName, bool transformThePoints) {
@@ -961,12 +970,12 @@ QString CemrgCommandLine::DockerCemrgNetPrediction(QString mra) {
 #if defined(__APPLE__)
     aPath = "/usr/local/bin/";
 #endif
+
     QFileInfo finfo(mra);
     QDir cemrgnethome(finfo.absolutePath());
     QString inputfilepath = cemrgnethome.absolutePath() + mitk::IOUtil::GetDirectorySeparator() + "test.nii";
     QString tempfilepath = cemrgnethome.absolutePath() + mitk::IOUtil::GetDirectorySeparator() + "output.nii";
     QString outputfilepath = cemrgnethome.absolutePath() + mitk::IOUtil::GetDirectorySeparator() + "LA-cemrgnet.nii";
-
     bool test;
     QString res;
 
@@ -987,7 +996,6 @@ QString CemrgCommandLine::DockerCemrgNetPrediction(QString mra) {
         QString docker = aPath+"docker";
         QString dockerimage = "orodrazeghi/cemrgnet";
         QStringList arguments;
-
         arguments << "run" << "--rm";
         arguments << "--volume="+cemrgnethome.absolutePath()+":/data";
         arguments << dockerimage;
@@ -1007,7 +1015,6 @@ QString CemrgCommandLine::DockerCemrgNetPrediction(QString mra) {
             std::this_thread::sleep_for(std::chrono::seconds(1));
             QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
         }
-        mitk::ProgressBar::GetInstance()->Progress();
 
         bool test2 = QFile::rename(tempfilepath, outputfilepath);
         if (test2) {
@@ -1182,7 +1189,6 @@ bool CemrgCommandLine::ExecuteCommand(QString executableName, QStringList argume
         std::this_thread::sleep_for(std::chrono::seconds(1));
         QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
     }
-    mitk::ProgressBar::GetInstance()->Progress();
 
     if (processStarted){
         successful = IsOutputSuccessful(outputPath);

--- a/Version2.0/Modules/CemrgAppModule/src/CemrgCommandLine.cpp
+++ b/Version2.0/Modules/CemrgAppModule/src/CemrgCommandLine.cpp
@@ -178,7 +178,7 @@ QString CemrgCommandLine::ExecuteCreateCGALMesh(QString dir, QString outputName,
             arguments << "-out_dir" << outputDirectory;
             arguments << "-out_name" << outputName;
 
-        } else {            
+        } else {
             QMessageBox::warning(NULL, "Please check the LOG", "MESHTOOLS3D libraries not found");
             MITK_WARN << "MESHTOOLS3D libraries not found. Please make sure the M3DLib folder is inside the directory:\n\t" + mitk::IOUtil::GetProgramPath();
         }//_if
@@ -222,7 +222,6 @@ void CemrgCommandLine::ExecuteTracking(QString dir, QString imgTimes, QString pa
     QString executableName;
     QString commandName = "register";
     QDir mirtkhome(dir);
-
     QString imgTimesFilePath, outAbsolutePath;
     QString prodPath = dir + mitk::IOUtil::GetDirectorySeparator();
     QStringList arguments;
@@ -236,14 +235,14 @@ void CemrgCommandLine::ExecuteTracking(QString dir, QString imgTimes, QString pa
     MITK_INFO << ("[...] OUTPUT DOF: " + outAbsolutePath).toStdString();
 
     if (_useDockerContainers) {
+
         MITK_INFO << "Using docker containers.";
 #if defined(__APPLE__)
         executablePath = "/usr/local/bin/";
 #endif
-
         executableName = executablePath+"docker";
-        arguments = GetDockerArguments(mirtkhome.absolutePath(), commandName);
 
+        arguments = GetDockerArguments(mirtkhome.absolutePath(), commandName);
         arguments << "-images" << mirtkhome.relativeFilePath(imgTimesFilePath);
         if (!param.isEmpty()) arguments << "-parin" << mirtkhome.relativeFilePath(param);
         arguments << "-dofout" << mirtkhome.relativeFilePath(outAbsolutePath);
@@ -251,6 +250,7 @@ void CemrgCommandLine::ExecuteTracking(QString dir, QString imgTimes, QString pa
         arguments << "-verbose" << "3";
 
     } else {
+
         MITK_INFO << "Using static MIRTK libraries.";
         executablePath = QString::fromStdString(mitk::IOUtil::GetProgramPath()) + mitk::IOUtil::GetDirectorySeparator() + "MLib";
 #if defined(__APPLE__)
@@ -258,12 +258,12 @@ void CemrgCommandLine::ExecuteTracking(QString dir, QString imgTimes, QString pa
                 mitk::IOUtil::GetDirectorySeparator() + QString("CemrgApp") +
                 mitk::IOUtil::GetDirectorySeparator() + QString("MLib");
 #endif
-
         executableName = executablePath + mitk::IOUtil::GetDirectorySeparator() + commandName;
         QDir apathd(executablePath);
-        if (apathd.exists()) {
-            process->setWorkingDirectory(executablePath);
 
+        if (apathd.exists()) {
+
+            process->setWorkingDirectory(executablePath);
             arguments << "-images" << imgTimesFilePath;
             if (!param.isEmpty()) arguments << "-parin" << param;
             arguments << "-dofout" << outAbsolutePath;
@@ -361,7 +361,7 @@ void CemrgCommandLine::ExecuteRegistration(QString dir, QString fixed, QString m
                 mitk::IOUtil::GetDirectorySeparator() + QString("CemrgApp") +
                 mitk::IOUtil::GetDirectorySeparator() + QString("MLib");
 #endif
-        executableName = executablePath + mitk::IOUtil::GetDirectorySeparator() + commandName;                
+        executableName = executablePath + mitk::IOUtil::GetDirectorySeparator() + commandName;
         QDir apathd(executablePath);
 
         if (apathd.exists()) {
@@ -475,33 +475,33 @@ void CemrgCommandLine::ExecuteSimpleTranslation(QString dir, QString sourceMeshP
 
     aPath = "";
     commandName = "init-dof"; //simple translation
-
     sourceMeshPath = sourceMeshP.contains(dir, Qt::CaseSensitive) ? sourceMeshP : prodPath + sourceMeshP;
     targetMeshPath = targetMeshP.contains(dir, Qt::CaseSensitive) ? targetMeshP : prodPath + targetMeshP;
     outAbsolutePath = transformFileName.contains(dir, Qt::CaseSensitive) ? transformFileName : prodPath + transformFileName;
 
     if (_useDockerContainers) {
+
         MITK_INFO << "Using docker containers.";
 #if defined(__APPLE__)
         aPath = "/usr/local/bin/";
 #endif
-
         executableName = aPath+"docker";
-        arguments = GetDockerArguments(mirtkhome.absolutePath(),  commandName);
 
+        arguments = GetDockerArguments(mirtkhome.absolutePath(),  commandName);
         arguments << mirtkhome.relativeFilePath(outAbsolutePath);
         arguments << "-translations" << "-norotations" << "-noscaling" << "-noshearing";
         if (transformThePoints) {
             arguments << "-displacements";
             arguments << mirtkhome.relativeFilePath(sourceMeshPath);
             arguments << mirtkhome.relativeFilePath(targetMeshPath);
-        }
-        else {
+        } else {
             arguments << "-source" << mirtkhome.relativeFilePath(sourceMeshPath);
             arguments << "-target" << mirtkhome.relativeFilePath(targetMeshPath);
-        }
+        }//_if
         arguments << "-verbose" << "3";
+
     } else {
+
         MITK_INFO << "Using static MIRTK libraries.";
         aPath = QString::fromStdString(mitk::IOUtil::GetProgramPath()) + mitk::IOUtil::GetDirectorySeparator() + "MLib";
         executableName = aPath + mitk::IOUtil::GetDirectorySeparator() + commandName;
@@ -511,9 +511,10 @@ void CemrgCommandLine::ExecuteSimpleTranslation(QString dir, QString sourceMeshP
                 mitk::IOUtil::GetDirectorySeparator() + QString("MLib");
 #endif
         QDir apathd(aPath);
-        if (apathd.exists()) {
-            process->setWorkingDirectory(aPath);
 
+        if (apathd.exists()) {
+
+            process->setWorkingDirectory(aPath);
             arguments << outAbsolutePath;
             arguments << "-translations" << "-norotations" << "-noscaling" << "-noshearing";
             if (transformThePoints) {
@@ -572,7 +573,6 @@ QString CemrgCommandLine::ExecuteMorphologicalOperation(QString operation, QStri
     }
 
     QDir mirtkhome(dir);
-
     QString inputImgFullPath, outAbsolutePath;
     QString prodPath = dir + mitk::IOUtil::GetDirectorySeparator();
 
@@ -588,15 +588,15 @@ QString CemrgCommandLine::ExecuteMorphologicalOperation(QString operation, QStri
 #if defined(__APPLE__)
         executablePath = "/usr/local/bin/";
 #endif
-
         executableName = executablePath+"docker";
-        arguments = GetDockerArguments(mirtkhome.absolutePath(), commandName);
 
+        arguments = GetDockerArguments(mirtkhome.absolutePath(), commandName);
         arguments << mirtkhome.relativeFilePath(inputImgFullPath);
         arguments << mirtkhome.relativeFilePath(outAbsolutePath);
         arguments << "-iterations" << QString::number(iter);
 
     } else {
+
         MITK_INFO << "Using static MIRTK libraries.";
         executablePath = QString::fromStdString(mitk::IOUtil::GetProgramPath()) + mitk::IOUtil::GetDirectorySeparator() + "MLib";
 #if defined(__APPLE__)
@@ -604,12 +604,12 @@ QString CemrgCommandLine::ExecuteMorphologicalOperation(QString operation, QStri
                 mitk::IOUtil::GetDirectorySeparator() + QString("CemrgApp") +
                 mitk::IOUtil::GetDirectorySeparator() + QString("MLib");
 #endif
-
         executableName = executablePath + mitk::IOUtil::GetDirectorySeparator() + commandName;
         QDir apathd(executablePath);
-        if (apathd.exists()) {
-            process->setWorkingDirectory(executablePath);
 
+        if (apathd.exists()) {
+
+            process->setWorkingDirectory(executablePath);
             arguments << inputImgFullPath;
             arguments << outAbsolutePath;
             arguments << "-iterations" << QString::number(iter);
@@ -643,11 +643,8 @@ QString CemrgCommandLine::ExecuteExtractSurface(QString dir, QString segPath, QS
     QString executablePath = "";
     QString executableName;
     QString commandName;
-
     commandName = "extract-surface";
-
     QDir mirtkhome(dir);
-
     QString inputImgFullPath, outAbsolutePath;
     QString prodPath = dir + mitk::IOUtil::GetDirectorySeparator();
     QStringList arguments;
@@ -659,12 +656,13 @@ QString CemrgCommandLine::ExecuteExtractSurface(QString dir, QString segPath, QS
     MITK_INFO << ("[...] OUTPUT MESH: " + outAbsolutePath).toStdString();
 
     if (_useDockerContainers) {
+
         MITK_INFO << "Using docker containers.";
 #if defined(__APPLE__)
         executablePath = "/usr/local/bin/";
 #endif
-
         executableName = executablePath+"docker";
+
         arguments = GetDockerArguments(mirtkhome.absolutePath(), commandName);
         arguments << mirtkhome.relativeFilePath(inputImgFullPath);
         arguments << mirtkhome.relativeFilePath(outAbsolutePath);
@@ -682,12 +680,12 @@ QString CemrgCommandLine::ExecuteExtractSurface(QString dir, QString segPath, QS
                 mitk::IOUtil::GetDirectorySeparator() + QString("CemrgApp") +
                 mitk::IOUtil::GetDirectorySeparator() + QString("MLib");
 #endif
-
         executableName = executablePath + mitk::IOUtil::GetDirectorySeparator() + commandName;
         QDir apathd(executablePath);
-        if (apathd.exists()) {
-            process->setWorkingDirectory(executablePath);
 
+        if (apathd.exists()) {
+
+            process->setWorkingDirectory(executablePath);
             arguments << inputImgFullPath;
             arguments << outAbsolutePath;
             arguments << "-isovalue" << QString::number(th);
@@ -737,20 +735,21 @@ QString CemrgCommandLine::ExecuteSmoothSurface(QString dir, QString segPath, QSt
     MITK_INFO << ("[...] OUTPUT MESH: " + outAbsolutePath).toStdString();
 
     if (_useDockerContainers) {
+
         MITK_INFO << "Using docker containers.";
 #if defined(__APPLE__)
         executablePath = "/usr/local/bin/";
 #endif
-
         executableName = executablePath+"docker";
-        arguments = GetDockerArguments(mirtkhome.absolutePath(), commandName);
 
+        arguments = GetDockerArguments(mirtkhome.absolutePath(), commandName);
         arguments << mirtkhome.relativeFilePath(inputMeshFullPath);
         arguments << mirtkhome.relativeFilePath(outAbsolutePath);
         arguments << "-iterations" << QString::number(smth);
         arguments << "-verbose" << "3";
 
     } else {
+
         MITK_INFO << "Using static MIRTK libraries.";
         executablePath = QString::fromStdString(mitk::IOUtil::GetProgramPath()) + mitk::IOUtil::GetDirectorySeparator() + "MLib";
 #if defined(__APPLE__)
@@ -758,12 +757,12 @@ QString CemrgCommandLine::ExecuteSmoothSurface(QString dir, QString segPath, QSt
                 mitk::IOUtil::GetDirectorySeparator() + QString("CemrgApp") +
                 mitk::IOUtil::GetDirectorySeparator() + QString("MLib");
 #endif
-
         executableName = executablePath + mitk::IOUtil::GetDirectorySeparator() + commandName;
         QDir apathd(executablePath);
-        if (apathd.exists()) {
-            process->setWorkingDirectory(executablePath);
 
+        if (apathd.exists()) {
+
+            process->setWorkingDirectory(executablePath);
             arguments << inputMeshFullPath;
             arguments << outAbsolutePath;
             arguments << "-iterations" << QString::number(smth);
@@ -780,18 +779,13 @@ QString CemrgCommandLine::ExecuteSmoothSurface(QString dir, QString segPath, QSt
 
     if (!successful) {
         if (_useDockerContainers) {
-
             MITK_WARN << "Docker did not produce a good outcome. Trying with local MIRTK libraries.";
             SetUseDockerContainersOff();
             return ExecuteSmoothSurface(dir, segPath, outputPath, smth);
-
         } else {
-
             MITK_WARN << "Local MIRTK libraries did not produce a good outcome.";
             return "ERROR_IN_PROCESSING";
-
         }//_if_docker
-
     } else {
         return outAbsolutePath;
     }
@@ -804,7 +798,6 @@ void CemrgCommandLine::ExecuteTransformationOnPoints(QString dir, QString meshFu
     QString executableName;
     QString commandName = "transform-points";
     QDir mirtkhome(dir);
-
     QString dofpath, inputMeshFullPath, outAbsolutePath;
     QString prodPath = dir + mitk::IOUtil::GetDirectorySeparator();
     QStringList arguments;
@@ -823,10 +816,9 @@ void CemrgCommandLine::ExecuteTransformationOnPoints(QString dir, QString meshFu
 #if defined(__APPLE__)
         executablePath = "/usr/local/bin/";
 #endif
-
         executableName = executablePath+"docker";
-        arguments = GetDockerArguments(mirtkhome.absolutePath(), commandName);
 
+        arguments = GetDockerArguments(mirtkhome.absolutePath(), commandName);
         arguments << mirtkhome.relativeFilePath(inputMeshFullPath); // input
         arguments << mirtkhome.relativeFilePath(outAbsolutePath); // output
         arguments << "-dofin" << mirtkhome.relativeFilePath(dofpath);
@@ -839,6 +831,7 @@ void CemrgCommandLine::ExecuteTransformationOnPoints(QString dir, QString meshFu
         arguments << "-verbose" << "3";
 
     } else {
+
         MITK_INFO << "Using static MIRTK libraries.";
         executablePath = QString::fromStdString(mitk::IOUtil::GetProgramPath()) + mitk::IOUtil::GetDirectorySeparator() + "MLib";
 #if defined(__APPLE__)
@@ -846,12 +839,12 @@ void CemrgCommandLine::ExecuteTransformationOnPoints(QString dir, QString meshFu
                 mitk::IOUtil::GetDirectorySeparator() + QString("CemrgApp") +
                 mitk::IOUtil::GetDirectorySeparator() + QString("MLib");
 #endif
-
         executableName = executablePath + mitk::IOUtil::GetDirectorySeparator() + commandName;
         QDir apathd(executablePath);
-        if (apathd.exists()) {
-            process->setWorkingDirectory(executablePath);
 
+        if (apathd.exists()) {
+
+            process->setWorkingDirectory(executablePath);
             arguments << inputMeshFullPath; // input
             arguments << outAbsolutePath; // output
             arguments << "-dofin" << dofpath;
@@ -893,7 +886,6 @@ void CemrgCommandLine::ExecuteResamplingOnNifti(QString niiFullPath, QString out
     QFileInfo inputnii(niiFullPath);
     QString dir = inputnii.absolutePath();
     QDir mirtkhome(dir);
-
     QString dofpath, imgNamefullpath, outAbsolutePath;
     QString prodPath = dir + mitk::IOUtil::GetDirectorySeparator();
     QStringList arguments;
@@ -910,10 +902,9 @@ void CemrgCommandLine::ExecuteResamplingOnNifti(QString niiFullPath, QString out
 #if defined(__APPLE__)
         executablePath = "/usr/local/bin/";
 #endif
-
         executableName = executablePath+"docker";
-        arguments = GetDockerArguments(mirtkhome.absolutePath(), commandName);
 
+        arguments = GetDockerArguments(mirtkhome.absolutePath(), commandName);
         arguments << mirtkhome.relativeFilePath(imgNamefullpath); //input
         arguments << mirtkhome.relativeFilePath(outAbsolutePath); //output
         arguments << "-isotropic" << QString::number(isovalue);
@@ -927,12 +918,12 @@ void CemrgCommandLine::ExecuteResamplingOnNifti(QString niiFullPath, QString out
 #if defined(__APPLE__)
         executablePath = mitk::IOUtil::GetDirectorySeparator() + QString("Applications") + mitk::IOUtil::GetDirectorySeparator() + QString("CemrgApp") + mitk::IOUtil::GetDirectorySeparator() + QString("MLib");
 #endif
-
         executableName = executablePath + mitk::IOUtil::GetDirectorySeparator() + commandName;
         QDir apathd(executablePath);
-        if (apathd.exists()) {
-            process->setWorkingDirectory(executablePath);
 
+        if (apathd.exists()) {
+
+            process->setWorkingDirectory(executablePath);
             arguments << imgNamefullpath; //input
             arguments << outAbsolutePath; //output
             arguments << "-isotropic" << QString::number(isovalue);
@@ -970,7 +961,6 @@ QString CemrgCommandLine::DockerCemrgNetPrediction(QString mra) {
 #if defined(__APPLE__)
     aPath = "/usr/local/bin/";
 #endif
-
     QFileInfo finfo(mra);
     QDir cemrgnethome(finfo.absolutePath());
     QString inputfilepath = cemrgnethome.absolutePath() + mitk::IOUtil::GetDirectorySeparator() + "test.nii";
@@ -1036,7 +1026,8 @@ QString CemrgCommandLine::DockerCemrgNetPrediction(QString mra) {
     return res;
 }
 
-QString CemrgCommandLine::DockerDicom2Nifti(QString path2dicomfolder){
+QString CemrgCommandLine::DockerDicom2Nifti(QString path2dicomfolder) {
+
     MITK_INFO << "[ATTENTION] Attempting alternative DICOM to NIFTI conversion.";
 
     QDir dicomhome(path2dicomfolder);
@@ -1048,6 +1039,7 @@ QString CemrgCommandLine::DockerDicom2Nifti(QString path2dicomfolder){
     MITK_INFO << ("[...] OUTPUT IMAGE: " + outAbsolutePath).toStdString();
 
     if (_useDockerContainers) {
+
         MITK_INFO << "Using docker containers.";
 #if defined(__APPLE__)
         executablePath = "/usr/local/bin/";
@@ -1056,7 +1048,6 @@ QString CemrgCommandLine::DockerDicom2Nifti(QString path2dicomfolder){
         QString executableName = executablePath+"docker";
 
         QStringList arguments;
-
         arguments << "run" << "--rm"  << "--volume="+dicomhome.absolutePath()+":/Data";
         arguments << "orodrazeghi/dicom-converter" << ".";
         arguments << "--gantry" << "--inconsistent";
@@ -1065,14 +1056,15 @@ QString CemrgCommandLine::DockerDicom2Nifti(QString path2dicomfolder){
 
     } else {
         MITK_WARN << "Docker must be running for this feature to be used.";
-    }
+    }//_if
 
     if (successful) {
         MITK_INFO << "Conversion successful.";
         outAbsolutePath = outPath;
     } else{
         MITK_WARN << "Error with DICOM2NIFTI Docker container.";
-    }
+    }//_if
+
     return outAbsolutePath;
 }
 
@@ -1175,12 +1167,14 @@ std::string CemrgCommandLine::PrintFullCommand(QString command, QStringList argu
         prodFile1 << (command + " " + argumentList).toStdString() << "\n";
         prodFile1.close();
     }//_if
+
     return (command + " " + argumentList).toStdString();
 }
 
 bool CemrgCommandLine::ExecuteCommand(QString executableName, QStringList arguments, QString outputPath) {
 
     MITK_INFO << PrintFullCommand(executableName, arguments);
+
     completion = false;
     process->start(executableName, arguments);
     bool successful = false;
@@ -1189,10 +1183,10 @@ bool CemrgCommandLine::ExecuteCommand(QString executableName, QStringList argume
         std::this_thread::sleep_for(std::chrono::seconds(1));
         QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
     }
-
     if (processStarted){
         successful = IsOutputSuccessful(outputPath);
     }
+
     return successful;
 }
 

--- a/Version2.0/Modules/CemrgAppModule/src/CemrgCommonUtils.cpp
+++ b/Version2.0/Modules/CemrgAppModule/src/CemrgCommonUtils.cpp
@@ -342,12 +342,9 @@ void CemrgCommonUtils::ConvertToCarto(std::string vtkPath) {
 
     //Header
     cartoFile << "# vtk DataFile Version 3.0\n";
-    cartoFile << "vtk output\n";
+    cartoFile << "PatientData Anon Anon 00000000\n";
     cartoFile << "ASCII\n";
     cartoFile << "DATASET POLYDATA\n";
-
-    //answer = inputdlg({'firstname', 'surname', 'ID'});
-    //vtktitle = ['PatientData ' answer{1} ' ' answer{2} ' ' answer{3}];
 
     //Points
     cartoFile << "POINTS\t" << pd->GetNumberOfPoints() << "\tfloat\n";
@@ -373,9 +370,7 @@ void CemrgCommonUtils::ConvertToCarto(std::string vtkPath) {
     //Point data
     vtkSmartPointer<vtkFloatArray> pointData = vtkSmartPointer<vtkFloatArray>::New();
     try {
-
         pointData = vtkFloatArray::SafeDownCast(pd->GetPointData()->GetScalars());
-
     } catch (...) {
         MITK_WARN << "Storing point data failed! Check your input";
         return;
@@ -421,40 +416,10 @@ void CemrgCommonUtils::ConvertToCarto(std::string vtkPath) {
 
     MITK_INFO << "Storing lookup table, min/max scalar values: " << min << " " << max;
 
-    //cartoFile << "LOOKUP_TABLE lookup_table 3\n";
-    //cartoFile << "0.0 0.0 1.0 1.0" << "\n";
-    //cartoFile << "1.0 1.0 1.0 1.0" << "\n";
-    //cartoFile << "0.0 1.0 0.0 1.0" << "\n";
-
-    //Cell data
-    vtkSmartPointer<vtkFloatArray> cellData = vtkSmartPointer<vtkFloatArray>::New();
-    try {
-
-        cellData = vtkFloatArray::SafeDownCast(pd->GetCellData()->GetScalars());
-
-    } catch (...) {
-        MITK_WARN << "Storing cell data failed! Check your input";
-        return;
-    }//_try
-
-    MITK_INFO << "Storing cell data, number of tuples: " << cellData->GetNumberOfTuples();
-
-    if (cellData->GetNumberOfTuples() != 0) {
-
-        cartoFile << "\nCELL_DATA\t";
-        cartoFile << cellData->GetNumberOfTuples() << "\n";
-
-        for (int i=0; i<cellData->GetNumberOfComponents(); i++) {
-
-            cartoFile << "SCALARS " << "scalars" << i << " float\n";
-            cartoFile << "LOOKUP_TABLE default\n";
-            for (int j=0; j<cellData->GetNumberOfTuples(); j++)
-                cartoFile << cellData->GetTuple(j)[i] << " ";
-            cartoFile << "\n";
-
-        }
-    }//_cell_data
-
+    cartoFile << "LOOKUP_TABLE lookup_table 3\n";
+    cartoFile << "0.0 0.0 1.0 1.0" << "\n";
+    cartoFile << "1.0 1.0 1.0 1.0" << "\n";
+    cartoFile << "0.0 1.0 0.0 1.0" << "\n";
     cartoFile.close();
 }
 

--- a/Version2.0/Modules/CemrgAppModule/src/CemrgCommonUtils.cpp
+++ b/Version2.0/Modules/CemrgAppModule/src/CemrgCommonUtils.cpp
@@ -234,13 +234,17 @@ mitk::Image::Pointer CemrgCommonUtils::IsoImageResampleReorient(mitk::Image::Poi
     return image;
 }
 
-mitk::Image::Pointer CemrgCommonUtils::IsoImageResampleReorient(QString imPath, bool resample,  bool reorientToRAI){
-    return CemrgCommonUtils::IsoImageResampleReorient(mitk::IOUtil::Load<mitk::Image>(imPath.toStdString()), resample, reorientToRAI);
-};
+mitk::Image::Pointer CemrgCommonUtils::IsoImageResampleReorient(QString imPath, bool resample,  bool reorientToRAI) {
 
-bool CemrgCommonUtils::ConvertToNifti(mitk::BaseData::Pointer oneNode, QString path2file, bool resample, bool reorient){
+    return CemrgCommonUtils::IsoImageResampleReorient(mitk::IOUtil::Load<mitk::Image>(imPath.toStdString()), resample, reorientToRAI);
+}
+
+bool CemrgCommonUtils::ConvertToNifti(mitk::BaseData::Pointer oneNode, QString path2file, bool resample, bool reorient) {
+
     bool successful = false;
+
     if (oneNode) {
+
         mitk::Image::Pointer image = dynamic_cast<mitk::Image*>(oneNode.GetPointer());
         if (image) { //Test if this data item is an image
             image = CemrgCommonUtils::IsoImageResampleReorient(image, resample, reorient);
@@ -248,10 +252,12 @@ bool CemrgCommonUtils::ConvertToNifti(mitk::BaseData::Pointer oneNode, QString p
             successful = true;
         } else{
             MITK_INFO << "[...] Problem casting node data to image";
-        }
+        }//_if
+
     } else{
         MITK_INFO << "[...] Problem with node";
-    }
+    }//_if
+
     return successful;
 }
 
@@ -427,7 +433,7 @@ void CemrgCommonUtils::ConvertToCarto(std::string vtkPath) {
         if (pointData->GetNumberOfComponents() == 1) {
 
             cartoFile << "SCALARS scalars float\n";
-            cartoFile << "LOOKUP_TABLE default\n";
+            cartoFile << "LOOKUP_TABLE lookup_table\n";
             for (int i=0; i<pointData->GetNumberOfTuples(); i++) {
                 double value = static_cast<double>(pointData->GetTuple1(i));
                 value = (value - min) / (max - min);
@@ -442,7 +448,7 @@ void CemrgCommonUtils::ConvertToCarto(std::string vtkPath) {
             for (int i=0; pointData->GetNumberOfComponents(); i++) {
 
                 cartoFile << "SCALARS " << "scalars" << i << " float\n";
-                cartoFile << "LOOKUP_TABLE default\n";
+                cartoFile << "LOOKUP_TABLE lookup_table\n";
                 for (int j=0; j<pointData->GetNumberOfTuples(); j++)
                     cartoFile << pointData->GetTuple(j)[i] << " ";
                 cartoFile << "\n";
@@ -454,9 +460,9 @@ void CemrgCommonUtils::ConvertToCarto(std::string vtkPath) {
     MITK_INFO << "Storing lookup table, min/max scalar values: " << min << " " << max;
 
     cartoFile << "LOOKUP_TABLE lookup_table 3\n";
-    cartoFile << "0.0 0.0 1.0 1.0" << "\n";
-    cartoFile << "1.0 1.0 1.0 1.0" << "\n";
-    cartoFile << "0.0 1.0 0.0 1.0" << "\n";
+    cartoFile << "11.0 55.0 65.0 1.0"    << "\n";
+    cartoFile << "241.0 122.0 33.0 1.0"  << "\n";
+    cartoFile << "231.0 29.0 37.0 1.0"   << "\n";
     cartoFile.close();
 }
 

--- a/Version2.0/Modules/CemrgAppModule/src/CemrgCommonUtils.cpp
+++ b/Version2.0/Modules/CemrgAppModule/src/CemrgCommonUtils.cpp
@@ -346,6 +346,9 @@ void CemrgCommonUtils::ConvertToCarto(std::string vtkPath) {
     cartoFile << "ASCII\n";
     cartoFile << "DATASET POLYDATA\n";
 
+    //answer = inputdlg({'firstname', 'surname', 'ID'});
+    //vtktitle = ['PatientData ' answer{1} ' ' answer{2} ' ' answer{3}];
+
     //Points
     cartoFile << "POINTS\t" << pd->GetNumberOfPoints() << "\tfloat\n";
     for (int i=0; i<pd->GetNumberOfPoints(); i++) {
@@ -392,7 +395,7 @@ void CemrgCommonUtils::ConvertToCarto(std::string vtkPath) {
         if (pointData->GetNumberOfComponents() == 1) {
 
             cartoFile << "SCALARS scalars float\n";
-            cartoFile << "LOOKUP_TABLE lookup_table\n";
+            cartoFile << "LOOKUP_TABLE default\n";
             for (int i=0; i<pointData->GetNumberOfTuples(); i++) {
                 double value = static_cast<double>(pointData->GetTuple1(i));
                 value = (value - min) / (max - min);
@@ -418,10 +421,10 @@ void CemrgCommonUtils::ConvertToCarto(std::string vtkPath) {
 
     MITK_INFO << "Storing lookup table, min/max scalar values: " << min << " " << max;
 
-    cartoFile << "LOOKUP_TABLE lookup_table 3\n";
-    cartoFile << "0.0 0.0 1.0 1.0" << "\n";
-    cartoFile << "1.0 1.0 1.0 1.0" << "\n";
-    cartoFile << "0.0 1.0 0.0 1.0" << "\n";
+    //cartoFile << "LOOKUP_TABLE lookup_table 3\n";
+    //cartoFile << "0.0 0.0 1.0 1.0" << "\n";
+    //cartoFile << "1.0 1.0 1.0 1.0" << "\n";
+    //cartoFile << "0.0 1.0 0.0 1.0" << "\n";
 
     //Cell data
     vtkSmartPointer<vtkFloatArray> cellData = vtkSmartPointer<vtkFloatArray>::New();

--- a/Version2.0/Modules/CemrgAppModule/src/CemrgCommonUtils.cpp
+++ b/Version2.0/Modules/CemrgAppModule/src/CemrgCommonUtils.cpp
@@ -35,6 +35,7 @@ PURPOSE.  See the above copyright notices for more information.
 //VTK
 #include <vtkPolyData.h>
 #include <vtkPolyDataReader.h>
+#include <vtkPolyDataNormals.h>
 #include <vtkPointData.h>
 #include <vtkCellData.h>
 #include <vtkFloatArray.h>
@@ -565,6 +566,22 @@ void CemrgCommonUtils::MotionTrackingReport(QString directory, int timePoints) {
         writer->SetInputConnection(windowToImageFilter->GetOutputPort());
         writer->Write();
     }
+}
+
+void CemrgCommonUtils::CalculatePolyDataNormals(vtkSmartPointer<vtkPolyData>& pd, bool celldata) {
+
+    vtkSmartPointer<vtkPolyDataNormals> normals = vtkSmartPointer<vtkPolyDataNormals>::New();
+    vtkSmartPointer<vtkPolyData> tempPD = vtkSmartPointer<vtkPolyData>::New();
+    tempPD->DeepCopy(pd);
+    if (celldata) {
+        normals->ComputeCellNormalsOn();
+    } else{ // pointdata
+        normals->ComputePointNormalsOn();
+    }
+    normals->SetInputData(tempPD);
+    normals->SplittingOff();
+    normals->Update();
+    pd = normals->GetOutput();
 }
 
 mitk::DataNode::Pointer CemrgCommonUtils::AddToStorage(

--- a/Version2.0/Modules/CemrgAppModule/src/CemrgCommonUtils.cpp
+++ b/Version2.0/Modules/CemrgAppModule/src/CemrgCommonUtils.cpp
@@ -57,6 +57,7 @@ PURPOSE.  See the above copyright notices for more information.
 #include <vtkCutter.h>
 #include <vtkCamera.h>
 #include <vtkTransformPolyDataFilter.h>
+#include <vtkColorTransferFunction.h>
 
 //Qmitk
 #include <mitkBoundingObjectCutter.h>
@@ -459,10 +460,22 @@ void CemrgCommonUtils::ConvertToCarto(std::string vtkPath) {
 
     MITK_INFO << "Storing lookup table, min/max scalar values: " << min << " " << max;
 
-    cartoFile << "LOOKUP_TABLE lookup_table 3\n";
-    cartoFile << "11.0 55.0 65.0 1.0"    << "\n";
-    cartoFile << "241.0 122.0 33.0 1.0"  << "\n";
-    cartoFile << "231.0 29.0 37.0 1.0"   << "\n";
+    //LUT
+    int numCols = 256;
+    cartoFile << "LOOKUP_TABLE lookup_table " << numCols << "\n";
+    vtkSmartPointer<vtkColorTransferFunction> lut = vtkSmartPointer<vtkColorTransferFunction>::New();
+    lut->SetColorSpaceToRGB();
+    lut->AddRGBPoint(0.0, 0.04, 0.21, 0.25);
+    lut->AddRGBPoint(numCols/2.0, 0.94, 0.47, 0.12);
+    lut->AddRGBPoint(numCols-1.0, 0.90, 0.11, 0.14);
+    lut->SetScaleToLinear();
+    for (int i=0; i<numCols; i++) {
+        cartoFile << lut->GetColor(i)[0] << " ";
+        cartoFile << lut->GetColor(i)[1] << " ";
+        cartoFile << lut->GetColor(i)[2] << " ";
+        cartoFile << "1.0" <<"\n";
+    }//_for
+
     cartoFile.close();
 }
 

--- a/Version2.0/Modules/CemrgAppModule/src/CemrgCommonUtils.cpp
+++ b/Version2.0/Modules/CemrgAppModule/src/CemrgCommonUtils.cpp
@@ -164,49 +164,56 @@ mitk::Image::Pointer CemrgCommonUtils::Downsample(mitk::Image::Pointer image, in
     return image;
 }
 
-mitk::Image::Pointer CemrgCommonUtils::IsoImageResampling(mitk::Image::Pointer image, bool reorientToRAI){
-    MITK_INFO << "Resampling image to be isometric.";
+mitk::Image::Pointer CemrgCommonUtils::IsoImageResampleReorient(mitk::Image::Pointer image, bool resample, bool reorientToRAI){
+    MITK_INFO(resample) << "Resampling image to be isometric.";
     MITK_INFO(reorientToRAI) << "Doing a reorientation to RAI.";
 
     typedef itk::Image<short,3> ImageType;
     typedef itk::ResampleImageFilter<ImageType, ImageType> ResampleImageFilterType;
     typedef itk::BSplineInterpolateImageFunction<ImageType, double, double> BSplineInterpolatorType;
-    ImageType::Pointer itkImage = ImageType::New();
-    mitk::CastToItkImage(image, itkImage);
-
-    ResampleImageFilterType::Pointer resampler = ResampleImageFilterType::New();
-    BSplineInterpolatorType::Pointer binterp = BSplineInterpolatorType::New();
-    binterp->SetSplineOrder(3);
-    resampler->SetInterpolator(binterp);
-
-    resampler->SetInput(itkImage);
-    resampler->SetOutputOrigin(itkImage->GetOrigin());
-    ImageType::SizeType input_size = itkImage->GetLargestPossibleRegion().GetSize();
-    ImageType::SpacingType input_spacing = itkImage->GetSpacing();
-    ImageType::SizeType output_size;
-    ImageType::SpacingType output_spacing;
-    output_size[0] = input_size[0] * (input_spacing[0] / 1.0);
-    output_size[1] = input_size[1] * (input_spacing[1] / 1.0);
-    output_size[2] = input_size[2] * (input_spacing[2] / 1.0);
-    output_spacing [0] = 1.0;
-    output_spacing [1] = 1.0;
-    output_spacing [2] = 1.0;
-    resampler->SetSize(output_size);
-    resampler->SetOutputSpacing(output_spacing);
-    resampler->SetOutputDirection(itkImage->GetDirection());
-    resampler->UpdateLargestPossibleRegion();
+    ImageType::Pointer itkInputImage = ImageType::New();
+    ImageType::Pointer resampleOutput = ImageType::New();
     ImageType::Pointer outputImage = ImageType::New();
+    mitk::CastToItkImage(image, itkInputImage);
+
+    if(resample){
+        ResampleImageFilterType::Pointer resampler = ResampleImageFilterType::New();
+        BSplineInterpolatorType::Pointer binterp = BSplineInterpolatorType::New();
+        binterp->SetSplineOrder(3);
+        resampler->SetInterpolator(binterp);
+
+        resampler->SetInput(itkInputImage);
+        resampler->SetOutputOrigin(itkInputImage->GetOrigin());
+        ImageType::SizeType input_size = itkInputImage->GetLargestPossibleRegion().GetSize();
+        ImageType::SpacingType input_spacing = itkInputImage->GetSpacing();
+        ImageType::SizeType output_size;
+        ImageType::SpacingType output_spacing;
+        output_size[0] = input_size[0] * (input_spacing[0] / 1.0);
+        output_size[1] = input_size[1] * (input_spacing[1] / 1.0);
+        output_size[2] = input_size[2] * (input_spacing[2] / 1.0);
+        output_spacing [0] = 1.0;
+        output_spacing [1] = 1.0;
+        output_spacing [2] = 1.0;
+        resampler->SetSize(output_size);
+        resampler->SetOutputSpacing(output_spacing);
+        resampler->SetOutputDirection(itkInputImage->GetDirection());
+        resampler->UpdateLargestPossibleRegion();
+
+        resampleOutput = resampler->GetOutput();
+    } else{
+        resampleOutput = itkInputImage;
+    }
 
     if(reorientToRAI){
         typedef itk::OrientImageFilter<ImageType,ImageType> OrientImageFilterType;
         OrientImageFilterType::Pointer orienter = OrientImageFilterType::New();
         orienter->UseImageDirectionOn();
         orienter->SetDesiredCoordinateOrientationToAxial(); // RAI
-        orienter->SetInput(resampler->GetOutput());
+        orienter->SetInput(resampleOutput);
         orienter->Update();
         outputImage = orienter->GetOutput();
     } else{
-        outputImage = resampler->GetOutput();
+        outputImage = resampleOutput;
     }
 
     image = mitk::ImportItkImage(outputImage)->Clone();
@@ -214,9 +221,26 @@ mitk::Image::Pointer CemrgCommonUtils::IsoImageResampling(mitk::Image::Pointer i
     return image;
 }
 
-mitk::Image::Pointer CemrgCommonUtils::IsoImageResampling(QString imPath, bool reorientToRAI){
-    return CemrgCommonUtils::IsoImageResampling(mitk::IOUtil::Load<mitk::Image>(imPath.toStdString()), reorientToRAI);
+mitk::Image::Pointer CemrgCommonUtils::IsoImageResampleReorient(QString imPath, bool resample,  bool reorientToRAI){
+    return CemrgCommonUtils::IsoImageResampleReorient(mitk::IOUtil::Load<mitk::Image>(imPath.toStdString()), resample, reorientToRAI);
 };
+
+bool CemrgCommonUtils::ConvertToNifti(mitk::BaseData::Pointer oneNode, QString path2file, bool resample, bool reorient){
+    bool successful = false;
+    if (oneNode) {
+        mitk::Image::Pointer image = dynamic_cast<mitk::Image*>(oneNode.GetPointer());
+        if (image) { //Test if this data item is an image
+            image = CemrgCommonUtils::IsoImageResampleReorient(image, resample, reorient);
+            mitk::IOUtil::Save(image, path2file.toStdString());
+            successful = true;
+        } else{
+            MITK_INFO << "[...] Problem casting node data to image";
+        }
+    } else{
+        MITK_INFO << "[...] Problem with node";
+    }
+    return successful;
+}
 
 
 mitk::Surface::Pointer CemrgCommonUtils::LoadVTKMesh(std::string path) {

--- a/Version2.0/Modules/CemrgAppModule/src/CemrgScarAdvanced.cpp
+++ b/Version2.0/Modules/CemrgAppModule/src/CemrgScarAdvanced.cpp
@@ -172,26 +172,11 @@ std::string CemrgScarAdvanced::ScarOverlap(
     temp->GetPointData()->SetScalars(exploration_values);
 
     vtkSmartPointer<vtkPolyDataWriter> writer = vtkSmartPointer<vtkPolyDataWriter>::New();
-    writer->SetFileName((this->_outPath+"ScarOverlap.vtk").c_str());
+    writer->SetFileName((GetOutputPath()+"ScarOverlap.vtk").c_str());
     writer->SetInputData(temp);
     writer->Update();
 
-    return (this->_outPath+"ScarOverlap.vtk");
-}
-
-std::string CemrgScarAdvanced::PathAndPrefix() {
-
-    return (this->_outPath+ this->_leftrightpre +this->_prefix);
-}
-
-std::string CemrgScarAdvanced::GetPrefix() {
-
-    return (this->_leftrightpre +this->_prefix);
-}
-
-bool CemrgScarAdvanced::isPointIDArrayEmpty() {
-
-    return (_pointidarray.empty());
+    return (GetOutputPath()+"ScarOverlap.vtk");
 }
 
 std::string CemrgScarAdvanced::num2str(double num, int precision) {
@@ -199,6 +184,18 @@ std::string CemrgScarAdvanced::num2str(double num, int precision) {
     std::stringstream stream;
     stream << std::fixed << std::setprecision(precision) << num;
     return stream.str();
+}
+
+void CemrgScarAdvanced::SaveStrToFile(std::string path2file, std::string filename, std::string text){
+    MITK_INFO << "[AdvancedScar] Saving to file: " + path2file+filename;
+    ofstream outst;
+    std::stringstream ss;
+
+    ss << (path2file+filename);
+    outst.open(ss.str().c_str(), std::ios_base::out);
+
+    outst << text;
+    outst.close();
 }
 
 std::string CemrgScarAdvanced::PrintThresholdResults(double mean, double stdv, double val) {
@@ -210,6 +207,9 @@ std::string CemrgScarAdvanced::PrintThresholdResults(double mean, double stdv, d
             "Threshold value: " + num2str(this->_fill_threshold,2) + "\n\n" +
             "Surface Area of Ablation: " + num2str(this->fandi1_largestSurfaceArea,2) + " mm^2 \n" +
             "Scar Score: " + num2str(this->fandi1_scarScore,2) + "%";
+
+    SaveStrToFile(GetOutputPath(), _prefix + "_"+ GetSurfaceAreaFilename(), out);
+
     return out;
 }
 
@@ -226,6 +226,9 @@ std::string CemrgScarAdvanced::PrintAblationGapsResults(double mean, double stdv
             "Area of corridor: " + num2str(this->fandi2_corridorSurfaceArea,0) + " mm^2 \n" ;
     std::string strisweighted = (_weightedcorridor) ? "Weighted path" : "Geodesic";
     out = out + "\nShortest path calculation: " + strisweighted + "\n";
+
+    SaveStrToFile(PathAndPrefix()+"_", GetGapsFilename(), out);
+
     return out;
 }
 std::string CemrgScarAdvanced::PrintScarOverlapResults(double valpre, double valpost) {
@@ -245,6 +248,8 @@ std::string CemrgScarAdvanced::PrintScarOverlapResults(double valpre, double val
                 "(Both at threshold value: " + num2str(valpre,1) +")" + "\n\n";
     }
     out += "Percentage of PRE scar in POST scar: " + num2str(ros*100,3) + "%\n";
+
+    SaveStrToFile(GetOutputPath(), GetComparisonFilename(), out);
 
     return out;
 }
@@ -727,7 +732,7 @@ void CemrgScarAdvanced::TransformSource2Target() {
     Output_Poly->GetPointData()->SetScalars(Output_Poly_Scalar);
 
     vtkSmartPointer<vtkPolyDataWriter> writer = vtkSmartPointer<vtkPolyDataWriter>::New();
-    writer->SetFileName((this->_outPath+"MaxScarPre_OnPost.vtk").c_str());
+    writer->SetFileName((GetOutputPath()+"MaxScarPre_OnPost.vtk").c_str());
     writer->SetInputData(Output_Poly);
     writer->Write();
 }

--- a/Version2.0/Plugins/kcl.cemrgapp.easi/src/internal/EASIView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.easi/src/internal/EASIView.cpp
@@ -194,11 +194,12 @@ void EASIView::ConvertNII() {
     foreach (int idx, index) {
         path = directory + mitk::IOUtil::GetDirectorySeparator() + "dcm-" + QString::number(ctr++) + ".nii";
         successfulNitfi = CemrgCommonUtils::ConvertToNifti(nodes.at(idx)->GetData(), path);
-        if(successfulNitfi){
+        if (successfulNitfi) {
             this->GetDataStorage()->Remove(nodes.at(idx));
-        } else{
+        } else {
+            mitk::ProgressBar::GetInstance()->Progress(index.size());
             return;
-        }
+        }//_if
         mitk::ProgressBar::GetInstance()->Progress();
     }//for
 
@@ -241,10 +242,11 @@ void EASIView::CropinIMGS() {
 
         //Cut selected image
         this->BusyCursorOn();
-        mitk::ProgressBar::GetInstance()->AddStepsToDo(2);
+        mitk::ProgressBar::GetInstance()->AddStepsToDo(1);
         mitk::Image::Pointer outputImage = CemrgCommonUtils::CropImage();
         path = directory + mitk::IOUtil::GetDirectorySeparator() + CemrgCommonUtils::GetImageNode()->GetName().c_str() + ".nii";
         mitk::IOUtil::Save(outputImage, path.toStdString());
+        mitk::ProgressBar::GetInstance()->Progress();
         this->BusyCursorOff();
 
         //Update datastorage
@@ -338,6 +340,7 @@ void EASIView::ResampIMGS() {
                 mitk::Image::Pointer outputImage = CemrgCommonUtils::Downsample(image, factor);
                 path = directory + mitk::IOUtil::GetDirectorySeparator() + imgNode->GetName().c_str() + ".nii";
                 mitk::IOUtil::Save(outputImage, path.toStdString());
+                mitk::ProgressBar::GetInstance()->Progress();
                 this->BusyCursorOff();
 
                 //Update datastorage
@@ -480,6 +483,7 @@ void EASIView::CreateMesh() {
                     cmd->SetDockerImage(QString("alonsojasl/meshtools3d:v1.0"));
                     QString output = cmd->ExecuteCreateCGALMesh(directory, "CGALMesh", templatePath);
                     QMessageBox::information(NULL, "Attention", "Command Line Operations Finished!");
+                    mitk::ProgressBar::GetInstance()->Progress();
 
                     //Prepare Visualisation
                     mitk::BaseData::Pointer meshData = mitk::IOUtil::Load(output.toStdString()).at(0);
@@ -492,9 +496,8 @@ void EASIView::CreateMesh() {
                         point[2] += origin.GetElement(2);
                         vtkGrid->GetPoints()->SetPoint(i, point);
                     }//_for
-
-                    mitk::ProgressBar::GetInstance()->Progress();
                     CemrgCommonUtils::AddToStorage(mitkVtkGrid, "CGALMesh", this->GetDataStorage());
+                    mitk::ProgressBar::GetInstance()->Progress();
                     this->BusyCursorOff();
 
                 } else if (dialogCode == QDialog::Rejected) {

--- a/Version2.0/Plugins/kcl.cemrgapp.easi/src/internal/EASIView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.easi/src/internal/EASIView.cpp
@@ -187,22 +187,18 @@ void EASIView::ConvertNII() {
     //Convert to Nifti
     int ctr = 0;
     QString path;
+    bool successfulNitfi;
     this->BusyCursorOn();
     mitk::ProgressBar::GetInstance()->AddStepsToDo(index.size());
 
     foreach (int idx, index) {
-        mitk::BaseData::Pointer data = nodes.at(idx)->GetData();
-        if (data) {
-            //Test if this data item is an image
-            mitk::Image::Pointer image = dynamic_cast<mitk::Image*>(data.GetPointer());
-            if (image) {
-                path = directory + mitk::IOUtil::GetDirectorySeparator() + "dcm-" + QString::number(ctr++) + ".nii";
-                mitk::IOUtil::Save(image, path.toStdString());
-                this->GetDataStorage()->Remove(nodes.at(idx));
-            } else
-                return;
-        } else
+        path = directory + mitk::IOUtil::GetDirectorySeparator() + "dcm-" + QString::number(ctr++) + ".nii";
+        successfulNitfi = CemrgCommonUtils::ConvertToNifti(nodes.at(idx)->GetData(), path);
+        if(successfulNitfi){
+            this->GetDataStorage()->Remove(nodes.at(idx));
+        } else{
             return;
+        }
         mitk::ProgressBar::GetInstance()->Progress();
     }//for
 

--- a/Version2.0/Plugins/kcl.cemrgapp.easi/src/internal/EASIView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.easi/src/internal/EASIView.cpp
@@ -188,9 +188,9 @@ void EASIView::ConvertNII() {
     int ctr = 0;
     QString path;
     bool successfulNitfi;
+
     this->BusyCursorOn();
     mitk::ProgressBar::GetInstance()->AddStepsToDo(index.size());
-
     foreach (int idx, index) {
         path = directory + mitk::IOUtil::GetDirectorySeparator() + "dcm-" + QString::number(ctr++) + ".nii";
         successfulNitfi = CemrgCommonUtils::ConvertToNifti(nodes.at(idx)->GetData(), path);
@@ -202,7 +202,6 @@ void EASIView::ConvertNII() {
         }//_if
         mitk::ProgressBar::GetInstance()->Progress();
     }//for
-
     nodes.clear();
     this->BusyCursorOff();
 

--- a/Version2.0/Plugins/kcl.cemrgapp.easi/src/internal/EASIView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.easi/src/internal/EASIView.cpp
@@ -473,7 +473,7 @@ void EASIView::CreateMesh() {
 
                     //Checking input files
                     if (templatePath.isEmpty()) {
-                        templatePath = CemrgCommonUtils::m3dlibParamFileGenerator(directory);
+                        templatePath = CemrgCommonUtils::M3dlibParamFileGenerator(directory);
                     }//_if
 
                     //Run Mesh3DTool

--- a/Version2.0/Plugins/kcl.cemrgapp.easi/src/internal/EASIViewUIMeshing.ui
+++ b/Version2.0/Plugins/kcl.cemrgapp.easi/src/internal/EASIViewUIMeshing.ui
@@ -7,8 +7,14 @@
     <x>0</x>
     <y>0</y>
     <width>500</width>
-    <height>97</height>
+    <height>103</height>
    </rect>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>103</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Set Values</string>

--- a/Version2.0/Plugins/kcl.cemrgapp.mainapp/files.cmake
+++ b/Version2.0/Plugins/kcl.cemrgapp.mainapp/files.cmake
@@ -15,6 +15,7 @@ set(INTERNAL_CPP_FILES
 )
 
 set(UI_FILES
+  src/internal/QmitkCemrgAppCartoExport.ui
   src/internal/QmitkCemrgAppCommonToolsControls.ui
 )
 

--- a/Version2.0/Plugins/kcl.cemrgapp.mainapp/src/internal/QmitkCemrgAppCartoExport.ui
+++ b/Version2.0/Plugins/kcl.cemrgapp.mainapp/src/internal/QmitkCemrgAppCartoExport.ui
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>WallThicknessCalculationsViewUIMeshing</class>
- <widget class="QWidget" name="WallThicknessCalculationsViewUIMeshing">
+ <class>QmitkCemrgAppCartoExport</class>
+ <widget class="QWidget" name="QmitkCemrgAppCartoExport">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>222</width>
-    <height>227</height>
+    <width>230</width>
+    <height>364</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -18,14 +18,14 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>0</width>
-    <height>227</height>
+    <width>230</width>
+    <height>364</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>16777215</width>
-    <height>227</height>
+    <width>230</width>
+    <height>364</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -38,7 +38,7 @@
       <string notr="true">QLabel { color: rgb(255, 0, 0) }</string>
      </property>
      <property name="text">
-      <string>Enter Algorithms Parameters</string>
+      <string>Enter Thresholding Parameters</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
@@ -46,43 +46,91 @@
     </widget>
    </item>
    <item>
+    <widget class="QRadioButton" name="radioButton_1">
+     <property name="text">
+      <string>Image Intensity Ratio</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QRadioButton" name="radioButton_2">
+     <property name="text">
+      <string>Mean + number of SD</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="Line" name="line_1">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_1">
+     <property name="text">
+      <string>Threshold Value(s)</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QLineEdit" name="lineEdit_1">
+     <property name="placeholderText">
+      <string>1.2; 1.32</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_2">
      <property name="text">
-      <string/>
-     </property>
-     <property name="placeholderText">
-      <string>Iteration (default = 1)</string>
+      <string>Mean Blood Pool Intensity</string>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QLineEdit" name="lineEdit_2">
-     <property name="placeholderText">
-      <string>Threshold (default = 0.5)</string>
-     </property>
-    </widget>
+    <widget class="QLineEdit" name="lineEdit_2"/>
    </item>
    <item>
-    <widget class="QLineEdit" name="lineEdit_3">
-     <property name="placeholderText">
-      <string>Blur (default = 0)</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLineEdit" name="lineEdit_4">
+    <widget class="QLabel" name="label_3">
      <property name="text">
-      <string/>
-     </property>
-     <property name="placeholderText">
-      <string>Smooth (default = 10)</string>
+      <string>SD Blood Pool Intensity</string>
      </property>
     </widget>
    </item>
    <item>
-    <widget class="QLineEdit" name="lineEdit_5">
-     <property name="placeholderText">
-      <string>Decimate (default = 0.9)</string>
+    <widget class="QLineEdit" name="lineEdit_3"/>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Colour Map Scheme</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QComboBox" name="comboBox">
+     <property name="editable">
+      <bool>false</bool>
+     </property>
+     <item>
+      <property name="text">
+       <string>Discrete</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Continuous</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item>
+    <widget class="Line" name="line_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>

--- a/Version2.0/Plugins/kcl.cemrgapp.mainapp/src/internal/QmitkCemrgAppCommonTools.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.mainapp/src/internal/QmitkCemrgAppCommonTools.cpp
@@ -53,6 +53,7 @@ void QmitkCemrgAppCommonTools::CreateQtPartControl(QWidget *parent) {
     // create GUI widgets from the Qt Designer's .ui file
     m_Controls.setupUi(parent);
     connect(m_Controls.button_1, &QPushButton::clicked, this, &QmitkCemrgAppCommonTools::LoadMesh);
+    connect(m_Controls.button_2, &QPushButton::clicked, this, &QmitkCemrgAppCommonTools::ConvertToCarto);
 }
 
 void QmitkCemrgAppCommonTools::SetFocus() {
@@ -69,4 +70,19 @@ void QmitkCemrgAppCommonTools::LoadMesh() {
                 NULL, "Open Mesh Data File", QmitkIOUtil::GetFileOpenFilterString());
     CemrgCommonUtils::AddToStorage(
                 CemrgCommonUtils::LoadVTKMesh(path.toStdString()), "Mesh", this->GetDataStorage());
+}
+
+void QmitkCemrgAppCommonTools::ConvertToCarto() {
+
+    QString path = "";
+    path = QFileDialog::getOpenFileName(
+                NULL, "Open Mesh Data File", QmitkIOUtil::GetFileOpenFilterString());
+
+    if (path.isEmpty() || !path.endsWith(".vtk")) {
+        QMessageBox::warning(NULL, "Attention", "Select Correct Input File!");
+        return;
+    }
+
+    CemrgCommonUtils::ConvertToCarto(path.toStdString());
+    QMessageBox::information(NULL, "Attention", "Conversion Completed!");
 }

--- a/Version2.0/Plugins/kcl.cemrgapp.mainapp/src/internal/QmitkCemrgAppCommonTools.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.mainapp/src/internal/QmitkCemrgAppCommonTools.cpp
@@ -83,6 +83,125 @@ void QmitkCemrgAppCommonTools::ConvertToCarto() {
         return;
     }
 
-    CemrgCommonUtils::ConvertToCarto(path.toStdString());
-    QMessageBox::information(NULL, "Attention", "Conversion Completed!");
+    //Find thresholds file
+    double fileMeanBP = 0.0;
+    double fileStdvBP = 0.0;
+    bool threshFileExist = false;
+    QFileInfo fullPathInfo(path);
+    if (fullPathInfo.dir().exists("prodThresholds.txt")) {
+
+        //Threshold file
+        QString tPath = fullPathInfo.absolutePath() + mitk::IOUtil::GetDirectorySeparator() + "prodThresholds.txt";
+        ifstream prodFileRead(tPath.toStdString());
+        if (prodFileRead.is_open()) {
+
+            std::string line;
+            std::vector<std::string> lines;
+            while (getline(prodFileRead, line))
+                lines.push_back(line);
+            fileMeanBP = QString::fromStdString(lines.at(2)).toDouble();
+            fileStdvBP = QString::fromStdString(lines.at(3)).toDouble();
+            prodFileRead.close();
+            threshFileExist = true;
+
+        }//_if
+    }//_if
+
+    //Ask for user input to set the parameters
+    QDialog* inputs = new QDialog(0,0);
+    m_CartoUIThresholding.setupUi(inputs);
+    connect(m_CartoUIThresholding.buttonBox, SIGNAL(accepted()), inputs, SLOT(accept()));
+    connect(m_CartoUIThresholding.buttonBox, SIGNAL(rejected()), inputs, SLOT(reject()));
+    connect(m_CartoUIThresholding.radioButton_1, SIGNAL(toggled(bool)), this, SLOT(ConvertToCartoUITextUpdate()));
+    connect(m_CartoUIThresholding.comboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(ConvertToCartoUIUpdate()));
+    m_CartoUIThresholding.lineEdit_2->setPlaceholderText(QString::number(fileMeanBP));
+    m_CartoUIThresholding.lineEdit_3->setPlaceholderText(QString::number(fileStdvBP));
+    int dialogCode = inputs->exec();
+
+    //Act on dialog return code
+    if (dialogCode == QDialog::Accepted) {
+
+        //Methods
+        int methodType = m_CartoUIThresholding.radioButton_1->isChecked() ? 1 : 2;
+        bool discreteScheme = m_CartoUIThresholding.comboBox->currentIndex() == 0 ? true : false;
+
+        //Thresholds
+        bool ok0;
+        std::vector<double> thresholds;
+        QRegExp separator("(\\ |\\,|\\;|\\:|\\t)");
+        QStringList thresholdsInput = m_CartoUIThresholding.lineEdit_1->text().trimmed().split(separator);
+        for (QString item:thresholdsInput)
+            if (item.isEmpty())
+                thresholdsInput.removeOne(item);
+        if (discreteScheme && thresholdsInput.size()==0) {
+            QMessageBox::warning(NULL, "Attention", "Reverting to default threshold values!");
+            thresholds.push_back(methodType == 1 ? 1.20 : 3.0);
+            thresholds.push_back(methodType == 1 ? 1.32 : 4.0);
+        } else if (discreteScheme && thresholdsInput.count()>2) {
+            QMessageBox::warning(NULL, "Attention", "Parsing thresholds failed!\nReverting to default values.");
+            thresholds.push_back(methodType == 1 ? 1.20 : 3.0);
+            thresholds.push_back(methodType == 1 ? 1.32 : 4.0);
+        } else {
+            for (QString item:thresholdsInput) {
+                double thresh = item.toDouble(&ok0);
+                if (!ok0) {
+                    QMessageBox::warning(NULL, "Attention", "Parsing thresholds failed!\nReverting to default values.");
+                    thresholds.clear();
+                    thresholds.push_back(methodType == 1 ? 1.20 : 3.0);
+                    thresholds.push_back(methodType == 1 ? 1.32 : 4.0);
+                    break;
+                } else
+                    thresholds.push_back(thresh);
+            }//_for
+        }//_if
+
+        //BP values
+        bool ok1, ok2;
+        double meanBP = m_CartoUIThresholding.lineEdit_2->text().toDouble(&ok1);
+        double stdvBP = m_CartoUIThresholding.lineEdit_3->text().toDouble(&ok2);
+        if (discreteScheme && (!ok1 || !ok2)) {
+            if (threshFileExist) {
+                meanBP = fileMeanBP;
+                stdvBP = fileStdvBP;
+                QMessageBox::information(NULL, "Attention", "Blood pool intensity values from the file was successfully restored.");
+            } else {
+                QMessageBox::warning(NULL, "Attention", "Parsing blood pool intensity values failed! Try again please.");
+                return;
+            }//_if
+        }//_if
+
+        //Conversion
+        CemrgCommonUtils::ConvertToCarto(path.toStdString(), thresholds, meanBP, stdvBP, methodType, discreteScheme);
+        QMessageBox::information(NULL, "Attention", "Conversion Completed!");
+        inputs->deleteLater();
+
+    } else if (dialogCode == QDialog::Rejected) {
+        inputs->close();
+        inputs->deleteLater();
+    }//_if
+}
+
+void QmitkCemrgAppCommonTools::ConvertToCartoUIUpdate() {
+
+    if (m_CartoUIThresholding.comboBox->currentIndex() == 1) {
+        m_CartoUIThresholding.lineEdit_1->setEnabled(false);
+        m_CartoUIThresholding.lineEdit_2->setEnabled(false);
+        m_CartoUIThresholding.lineEdit_3->setEnabled(false);
+        m_CartoUIThresholding.radioButton_1->setEnabled(false);
+        m_CartoUIThresholding.radioButton_2->setEnabled(false);
+    } else {
+        m_CartoUIThresholding.lineEdit_1->setEnabled(true);
+        m_CartoUIThresholding.lineEdit_2->setEnabled(true);
+        m_CartoUIThresholding.lineEdit_3->setEnabled(true);
+        m_CartoUIThresholding.radioButton_1->setEnabled(true);
+        m_CartoUIThresholding.radioButton_2->setEnabled(true);
+    }//_if
+}
+
+void QmitkCemrgAppCommonTools::ConvertToCartoUITextUpdate() {
+
+    if (m_CartoUIThresholding.radioButton_1->isChecked())
+        m_CartoUIThresholding.lineEdit_1->setPlaceholderText("1.2; 1.32");
+    else
+        m_CartoUIThresholding.lineEdit_1->setPlaceholderText("3; 4");
 }

--- a/Version2.0/Plugins/kcl.cemrgapp.mainapp/src/internal/QmitkCemrgAppCommonTools.h
+++ b/Version2.0/Plugins/kcl.cemrgapp.mainapp/src/internal/QmitkCemrgAppCommonTools.h
@@ -31,6 +31,7 @@ PURPOSE.  See the above copyright notices for more information.
 
 #include <berryISelectionListener.h>
 #include <QmitkAbstractView.h>
+#include "ui_QmitkCemrgAppCartoExport.h"
 #include "ui_QmitkCemrgAppCommonToolsControls.h"
 
 /**
@@ -49,6 +50,14 @@ public:
 
     static const std::string VIEW_ID;
 
+protected slots:
+
+    /// \brief Called when the user clicks the GUI button
+    void LoadMesh();
+    void ConvertToCarto();
+    void ConvertToCartoUIUpdate();
+    void ConvertToCartoUITextUpdate();
+
 protected:
 
     virtual void CreateQtPartControl(QWidget *parent) override;
@@ -57,11 +66,7 @@ protected:
             berry::IWorkbenchPart::Pointer source, const QList<mitk::DataNode::Pointer>& nodes) override;
 
     Ui::QmitkCemrgAppCommonToolsControls m_Controls;
-
-    /// \brief Called when the user clicks the GUI button
-    void LoadMesh();
-    void ConvertToCarto();
-
+    Ui::QmitkCemrgAppCartoExport m_CartoUIThresholding;
 };
 
 #endif // QmitkCemrgAppCommonTools_h

--- a/Version2.0/Plugins/kcl.cemrgapp.mainapp/src/internal/QmitkCemrgAppCommonTools.h
+++ b/Version2.0/Plugins/kcl.cemrgapp.mainapp/src/internal/QmitkCemrgAppCommonTools.h
@@ -60,6 +60,8 @@ protected:
 
     /// \brief Called when the user clicks the GUI button
     void LoadMesh();
+    void ConvertToCarto();
+
 };
 
 #endif // QmitkCemrgAppCommonTools_h

--- a/Version2.0/Plugins/kcl.cemrgapp.mainapp/src/internal/QmitkCemrgAppCommonToolsControls.ui
+++ b/Version2.0/Plugins/kcl.cemrgapp.mainapp/src/internal/QmitkCemrgAppCommonToolsControls.ui
@@ -44,6 +44,16 @@
     </widget>
    </item>
    <item>
+    <widget class="QPushButton" name="button_2">
+     <property name="toolTip">
+      <string>Do image processing</string>
+     </property>
+     <property name="text">
+      <string>Convert to CARTO</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <spacer name="spacer1">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/Version2.0/Plugins/kcl.cemrgapp.mmcwplugin/src/internal/MmcwView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.mmcwplugin/src/internal/MmcwView.cpp
@@ -215,6 +215,7 @@ void MmcwView::ConvertNII() {
     int ctr = 0;
     QString path;
     bool successfulNitfi;
+
     this->BusyCursorOn();
     mitk::ProgressBar::GetInstance()->AddStepsToDo(index.size());
     foreach (int idx, index) {

--- a/Version2.0/Plugins/kcl.cemrgapp.mmcwplugin/src/internal/MmcwView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.mmcwplugin/src/internal/MmcwView.cpp
@@ -575,8 +575,8 @@ void MmcwView::CreateSurf() {
             QMessageBox::warning(NULL, "Attention", "Reverting to default parameters!");
         if (!ok1) iter = 1;
         if (!ok2) th   = 0.5;
-        if (!ok3) blur = 3;
-        if (!ok4) smth = 40;
+        if (!ok3) blur = 0;
+        if (!ok4) smth = 10;
         //_if
 
         this->BusyCursorOn();

--- a/Version2.0/Plugins/kcl.cemrgapp.mmcwplugin/src/internal/MmcwView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.mmcwplugin/src/internal/MmcwView.cpp
@@ -214,21 +214,18 @@ void MmcwView::ConvertNII() {
     //Convert to Nifti
     int ctr = 0;
     QString path;
+    bool successfulNitfi;
     this->BusyCursorOn();
     mitk::ProgressBar::GetInstance()->AddStepsToDo(index.size());
     foreach (int idx, index) {
         mitk::BaseData::Pointer data = nodes.at(idx)->GetData();
-        if (data) {
-            //Test if this data item is an image
-            mitk::Image::Pointer image = dynamic_cast<mitk::Image*>(data.GetPointer());
-            if (image) {
-                path = directory + mitk::IOUtil::GetDirectorySeparator() + "dcm-" + QString::number(ctr++) + ".nii";
-                mitk::IOUtil::Save(image, path.toStdString());
-                this->GetDataStorage()->Remove(nodes.at(idx));
-            } else
-                return;
-        } else
+        path = directory + mitk::IOUtil::GetDirectorySeparator() + "dcm-" + QString::number(ctr++) + ".nii";
+        successfulNitfi = CemrgCommonUtils::ConvertToNifti(nodes.at(idx)->GetData(), path);
+        if(successfulNitfi){
+            this->GetDataStorage()->Remove(nodes.at(idx));
+        } else{
             return;
+        }
         mitk::ProgressBar::GetInstance()->Progress();
     }//for
     nodes.clear();

--- a/Version2.0/Plugins/kcl.cemrgapp.mmcwplugin/src/internal/MmcwView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.mmcwplugin/src/internal/MmcwView.cpp
@@ -917,6 +917,9 @@ void MmcwView::Demoings() {
 
     //Show the plugin
     this->GetSite()->GetPage()->ShowView("org.mitk.views.imagenavigator");
+
+    //Report generation
+    CemrgCommonUtils::MotionTrackingReport(directory, timePoints);
 }
 
 void MmcwView::LandmarkSelection() {

--- a/Version2.0/Plugins/kcl.cemrgapp.mmcwplugin/src/internal/MmcwViewPlot.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.mmcwplugin/src/internal/MmcwViewPlot.cpp
@@ -184,6 +184,7 @@ void MmcwViewPlot::PlotData() {
     mitk::ProgressBar::GetInstance()->AddStepsToDo(1);
 
     //Define the reference mesh
+    mitk::Surface::Pointer refSurf;
     int segRatios[3] = {bas, mid, api};
     int pacingSegRatios[3] = {17, 33, 55};
     // This give the AHA region from 50 - 50+1/3 in middle - Ie putting pacing site at 2/3 height
@@ -196,15 +197,13 @@ void MmcwViewPlot::PlotData() {
         return;
     }
 
-    mitk::Surface::Pointer refSurf;
-
     //Calculate y values of the plots
     flatPlotScalars.clear();
     plotValueVectors.clear();
     std::string plotType = m_Controls.comboBox->currentText().toStdString();
+
     if (plotType.compare("Squeez") == 0) {
         refSurf = strain->ReferenceAHA(lmNode, segRatios, false);
-
         for (int i=0; i<noFrames*smoothness; i++) {
             plotValueVectors.push_back(strain->CalculateSqzPlot(i));
             vtkSmartPointer<vtkFloatArray> holder = vtkSmartPointer<vtkFloatArray>::New();
@@ -256,6 +255,7 @@ void MmcwViewPlot::PlotData() {
     //Visualise AHA plots
     HandleBullPlot(false);
     ColourAHASegments(m_Controls.horizontalSlider->value());
+
     //Visualise the curves plot
     HandleCurvPlot();
 
@@ -272,8 +272,6 @@ void MmcwViewPlot::PlotData() {
             this->GetDataStorage()->Remove(nodeIt->Value());
         if (nodeIt->Value()->GetName().compare("Guideline 3") == 0)
             this->GetDataStorage()->Remove(nodeIt->Value());
-        //if (nodeIt->Value()->GetName().compare("Guideline 4") == 0)
-        //    this->GetDataStorage()->Remove(nodeIt->Value());
     }//_for
     mitk::DataNode::Pointer node = mitk::DataNode::New();
     node->SetProperty("scalar visibility", mitk::BoolProperty::New(true));

--- a/Version2.0/Plugins/kcl.cemrgapp.mmcwplugin/src/internal/MmcwViewUIApplying.ui
+++ b/Version2.0/Plugins/kcl.cemrgapp.mmcwplugin/src/internal/MmcwViewUIApplying.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>417</width>
-    <height>250</height>
+    <width>342</width>
+    <height>243</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -18,8 +18,14 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>400</width>
-    <height>250</height>
+    <width>0</width>
+    <height>243</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>243</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -33,53 +39,6 @@
      </property>
      <property name="placeholderText">
       <string>Enter Number of Frames (default = 10)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QPushButton" name="pushButton_1">
-     <property name="text">
-      <string>Browse</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLineEdit" name="lineEdit_1">
-     <property name="text">
-      <string/>
-     </property>
-     <property name="placeholderText">
-      <string>Open the input mesh</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-     <property name="centerButtons">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QPushButton" name="pushButton_2">
-     <property name="text">
-      <string>Browse</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLineEdit" name="lineEdit_3">
-     <property name="placeholderText">
-      <string>Open the transformation file</string>
      </property>
     </widget>
    </item>
@@ -141,26 +100,26 @@
      </layout>
     </widget>
    </item>
-   <item row="7" column="0" colspan="2">
-    <spacer name="spacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+   <item row="3" column="1">
+    <widget class="QPushButton" name="pushButton_2">
+     <property name="text">
+      <string>Browse</string>
      </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Expanding</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>0</height>
-      </size>
-     </property>
-    </spacer>
+    </widget>
    </item>
-   <item row="2" column="0" colspan="2">
-    <widget class="QLineEdit" name="lineEdit_2">
-     <property name="placeholderText">
-      <string>Enter Initial Time (default = 0)</string>
+   <item row="6" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+     <property name="centerButtons">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
@@ -176,6 +135,53 @@
       <set>Qt::AlignCenter</set>
      </property>
     </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QPushButton" name="pushButton_1">
+     <property name="text">
+      <string>Browse</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLineEdit" name="lineEdit_1">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="placeholderText">
+      <string>Open the input mesh</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QLineEdit" name="lineEdit_2">
+     <property name="placeholderText">
+      <string>Enter Initial Time (default = 0)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLineEdit" name="lineEdit_3">
+     <property name="placeholderText">
+      <string>Open the transformation file</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="2">
+    <spacer name="spacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Expanding</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/Version2.0/Plugins/kcl.cemrgapp.mmcwplugin/src/internal/MmcwViewUIMeshing.ui
+++ b/Version2.0/Plugins/kcl.cemrgapp.mmcwplugin/src/internal/MmcwViewUIMeshing.ui
@@ -65,7 +65,7 @@
    <item>
     <widget class="QLineEdit" name="lineEdit_3">
      <property name="placeholderText">
-      <string>Blur (default = 3)</string>
+      <string>Blur (default = 0)</string>
      </property>
     </widget>
    </item>
@@ -75,7 +75,7 @@
       <string/>
      </property>
      <property name="placeholderText">
-      <string>Smooth (default = 40)</string>
+      <string>Smooth (default = 10)</string>
      </property>
     </widget>
    </item>

--- a/Version2.0/Plugins/kcl.cemrgapp.mmcwplugin/src/internal/MmcwViewUIMeshing.ui
+++ b/Version2.0/Plugins/kcl.cemrgapp.mmcwplugin/src/internal/MmcwViewUIMeshing.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>222</width>
-    <height>206</height>
+    <width>216</width>
+    <height>196</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,7 +19,13 @@
   <property name="minimumSize">
    <size>
     <width>0</width>
-    <height>0</height>
+    <height>196</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>196</height>
    </size>
   </property>
   <property name="windowTitle">

--- a/Version2.0/Plugins/kcl.cemrgapp.mmcwplugin/src/internal/MmcwViewUITracking.ui
+++ b/Version2.0/Plugins/kcl.cemrgapp.mmcwplugin/src/internal/MmcwViewUITracking.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>500</width>
-    <height>140</height>
+    <height>134</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,7 +19,13 @@
   <property name="minimumSize">
    <size>
     <width>500</width>
-    <height>0</height>
+    <height>134</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>134</height>
    </size>
   </property>
   <property name="windowTitle">

--- a/Version2.0/Plugins/kcl.cemrgapp.mmeasurement/src/internal/MmeasurementView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.mmeasurement/src/internal/MmeasurementView.cpp
@@ -197,14 +197,13 @@ void MmeasurementView::ConvertNII() {
     //Convert to Nifti
     int ctr = 0;
     QString path;
-    bool successfulNitfi, resampleImage, reorientToRAI;
-    resampleImage = false;
-    reorientToRAI = true;
+    bool successfulNitfi;
+
     this->BusyCursorOn();
     mitk::ProgressBar::GetInstance()->AddStepsToDo(index.size());
     foreach (int idx, index) {
         path = directory + mitk::IOUtil::GetDirectorySeparator() + "dcm-" + QString::number(ctr++) + ".nii";
-        successfulNitfi = CemrgCommonUtils::ConvertToNifti(nodes.at(idx)->GetData(), path, resampleImage, reorientToRAI);
+        successfulNitfi = CemrgCommonUtils::ConvertToNifti(nodes.at(idx)->GetData(), path);
         if (successfulNitfi) {
             this->GetDataStorage()->Remove(nodes.at(idx));
         } else {

--- a/Version2.0/Plugins/kcl.cemrgapp.mmeasurement/src/internal/MmeasurementView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.mmeasurement/src/internal/MmeasurementView.cpp
@@ -205,9 +205,10 @@ void MmeasurementView::ConvertNII() {
     foreach (int idx, index) {
         path = directory + mitk::IOUtil::GetDirectorySeparator() + "dcm-" + QString::number(ctr++) + ".nii";
         successfulNitfi = CemrgCommonUtils::ConvertToNifti(nodes.at(idx)->GetData(), path, resampleImage, reorientToRAI);
-        if(successfulNitfi){
+        if (successfulNitfi) {
             this->GetDataStorage()->Remove(nodes.at(idx));
-        } else{
+        } else {
+            mitk::ProgressBar::GetInstance()->Progress(index.size());
             return;
         }
         mitk::ProgressBar::GetInstance()->Progress();
@@ -261,10 +262,11 @@ void MmeasurementView::CropinIMGS() {
 
         //Cut selected image
         this->BusyCursorOn();
-        mitk::ProgressBar::GetInstance()->AddStepsToDo(2);
+        mitk::ProgressBar::GetInstance()->AddStepsToDo(1);
         mitk::Image::Pointer outputImage = CemrgCommonUtils::CropImage();
         path = directory + mitk::IOUtil::GetDirectorySeparator() + CemrgCommonUtils::GetImageNode()->GetName().c_str() + ".nii";
         mitk::IOUtil::Save(outputImage, path.toStdString());
+        mitk::ProgressBar::GetInstance()->Progress();
         this->BusyCursorOff();
 
         //Update datastorage
@@ -280,16 +282,16 @@ void MmeasurementView::CropinIMGS() {
         if (reply == QMessageBox::Yes) {
 
             this->BusyCursorOn();
-            mitk::ProgressBar::GetInstance()->AddStepsToDo((timePoints-1)*2);
+            mitk::ProgressBar::GetInstance()->AddStepsToDo(timePoints-1);
 
             for (int i=1; i<timePoints; i++) {
 
                 mitk::Image::Pointer inputImage;
                 path = directory + mitk::IOUtil::GetDirectorySeparator() + "dcm-" + QString::number(i) + ".nii";
                 try {
-                    inputImage = dynamic_cast<mitk::Image*>(
-                                mitk::IOUtil::Load(path.toStdString()).front().GetPointer());
+                    inputImage = dynamic_cast<mitk::Image*>(mitk::IOUtil::Load(path.toStdString()).front().GetPointer());
                 } catch(const std::exception& e) {
+                    mitk::ProgressBar::GetInstance()->Progress();
                     continue;
                 }//_try
 
@@ -297,8 +299,9 @@ void MmeasurementView::CropinIMGS() {
                 CemrgCommonUtils::SetImageToCut(inputImage);
                 outputImage = CemrgCommonUtils::CropImage();
                 mitk::IOUtil::Save(outputImage, path.toStdString());
-            }//_for
+                mitk::ProgressBar::GetInstance()->Progress();
 
+            }//_for
             this->BusyCursorOff();
         }//_if
 
@@ -397,6 +400,7 @@ void MmeasurementView::ResampIMGS() {
                 mitk::Image::Pointer outputImage = CemrgCommonUtils::Downsample(image, factor);
                 path = directory + mitk::IOUtil::GetDirectorySeparator() + imgNode->GetName().c_str() + ".nii";
                 mitk::IOUtil::Save(outputImage, path.toStdString());
+                mitk::ProgressBar::GetInstance()->Progress();
                 this->BusyCursorOff();
 
                 //Update datastorage
@@ -412,21 +416,22 @@ void MmeasurementView::ResampIMGS() {
                 if (reply == QMessageBox::Yes) {
 
                     this->BusyCursorOn();
-                    mitk::ProgressBar::GetInstance()->AddStepsToDo(9);
+                    mitk::ProgressBar::GetInstance()->AddStepsToDo(timePoints-1);
                     for (int i=1; i<timePoints; i++) {
 
                         mitk::Image::Pointer inputImage;
                         path = directory + mitk::IOUtil::GetDirectorySeparator() + "dcm-" + QString::number(i) + ".nii";
                         try {
-                            inputImage = dynamic_cast<mitk::Image*>(
-                                        mitk::IOUtil::Load(path.toStdString()).front().GetPointer());
+                            inputImage = dynamic_cast<mitk::Image*>(mitk::IOUtil::Load(path.toStdString()).front().GetPointer());
                         } catch(const std::exception& e) {
+                            mitk::ProgressBar::GetInstance()->Progress();
                             continue;
                         }//_try
 
                         //Setup sampler
                         outputImage = CemrgCommonUtils::Downsample(inputImage, factor);
                         mitk::IOUtil::Save(outputImage, path.toStdString());
+                        mitk::ProgressBar::GetInstance()->Progress();
 
                     }//_for
                     this->BusyCursorOff();

--- a/Version2.0/Plugins/kcl.cemrgapp.mmeasurement/src/internal/MmeasurementView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.mmeasurement/src/internal/MmeasurementView.cpp
@@ -197,12 +197,14 @@ void MmeasurementView::ConvertNII() {
     //Convert to Nifti
     int ctr = 0;
     QString path;
-    bool successfulNitfi;
+    bool successfulNitfi, resampleImage, reorientToRAI;
+    resampleImage = false;
+    reorientToRAI = true;
     this->BusyCursorOn();
     mitk::ProgressBar::GetInstance()->AddStepsToDo(index.size());
     foreach (int idx, index) {
         path = directory + mitk::IOUtil::GetDirectorySeparator() + "dcm-" + QString::number(ctr++) + ".nii";
-        successfulNitfi = CemrgCommonUtils::ConvertToNifti(nodes.at(idx)->GetData(), path);
+        successfulNitfi = CemrgCommonUtils::ConvertToNifti(nodes.at(idx)->GetData(), path, resampleImage, reorientToRAI);
         if(successfulNitfi){
             this->GetDataStorage()->Remove(nodes.at(idx));
         } else{

--- a/Version2.0/Plugins/kcl.cemrgapp.mmeasurement/src/internal/MmeasurementView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.mmeasurement/src/internal/MmeasurementView.cpp
@@ -197,21 +197,17 @@ void MmeasurementView::ConvertNII() {
     //Convert to Nifti
     int ctr = 0;
     QString path;
+    bool successfulNitfi;
     this->BusyCursorOn();
     mitk::ProgressBar::GetInstance()->AddStepsToDo(index.size());
     foreach (int idx, index) {
-        mitk::BaseData::Pointer data = nodes.at(idx)->GetData();
-        if (data) {
-            //Test if this data item is an image
-            mitk::Image::Pointer image = dynamic_cast<mitk::Image*>(data.GetPointer());
-            if (image) {
-                path = directory + mitk::IOUtil::GetDirectorySeparator() + "dcm-" + QString::number(ctr++) + ".nii";
-                mitk::IOUtil::Save(image, path.toStdString());
-                this->GetDataStorage()->Remove(nodes.at(idx));
-            } else
-                return;
-        } else
+        path = directory + mitk::IOUtil::GetDirectorySeparator() + "dcm-" + QString::number(ctr++) + ".nii";
+        successfulNitfi = CemrgCommonUtils::ConvertToNifti(nodes.at(idx)->GetData(), path);
+        if(successfulNitfi){
+            this->GetDataStorage()->Remove(nodes.at(idx));
+        } else{
             return;
+        }
         mitk::ProgressBar::GetInstance()->Progress();
     }//for
     nodes.clear();

--- a/Version2.0/Plugins/kcl.cemrgapp.mmeasurement/src/internal/MmeasurementViewUIApplying.ui
+++ b/Version2.0/Plugins/kcl.cemrgapp.mmeasurement/src/internal/MmeasurementViewUIApplying.ui
@@ -7,19 +7,19 @@
     <x>0</x>
     <y>0</y>
     <width>417</width>
-    <height>220</height>
+    <height>211</height>
    </rect>
-  </property>
-  <property name="sizePolicy">
-   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-    <horstretch>0</horstretch>
-    <verstretch>0</verstretch>
-   </sizepolicy>
   </property>
   <property name="minimumSize">
    <size>
-    <width>400</width>
-    <height>220</height>
+    <width>0</width>
+    <height>211</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>211</height>
    </size>
   </property>
   <property name="windowTitle">

--- a/Version2.0/Plugins/kcl.cemrgapp.mmeasurement/src/internal/MmeasurementViewUITracking.ui
+++ b/Version2.0/Plugins/kcl.cemrgapp.mmeasurement/src/internal/MmeasurementViewUITracking.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>500</width>
-    <height>126</height>
+    <height>134</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,7 +19,13 @@
   <property name="minimumSize">
    <size>
     <width>500</width>
-    <height>0</height>
+    <height>134</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>134</height>
    </size>
   </property>
   <property name="windowTitle">

--- a/Version2.0/Plugins/kcl.cemrgapp.powertrans/src/internal/powertransView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.powertrans/src/internal/powertransView.cpp
@@ -210,9 +210,9 @@ void powertransView::ConvertNII() {
     int ctr = 0;
     QString path;
     bool successfulNitfi;
+
     this->BusyCursorOn();
     mitk::ProgressBar::GetInstance()->AddStepsToDo(index.size());
-
     foreach (int idx, index) {
         path = directory + mitk::IOUtil::GetDirectorySeparator() + "dcm-" + QString::number(ctr++) + ".nii";
         successfulNitfi = CemrgCommonUtils::ConvertToNifti(nodes.at(idx)->GetData(), path);
@@ -224,7 +224,6 @@ void powertransView::ConvertNII() {
         }
         mitk::ProgressBar::GetInstance()->Progress();
     }//for
-
     nodes.clear();
     this->BusyCursorOff();
 

--- a/Version2.0/Plugins/kcl.cemrgapp.powertrans/src/internal/powertransView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.powertrans/src/internal/powertransView.cpp
@@ -209,22 +209,18 @@ void powertransView::ConvertNII() {
     //Convert to Nifti
     int ctr = 0;
     QString path;
+    bool successfulNitfi;
     this->BusyCursorOn();
     mitk::ProgressBar::GetInstance()->AddStepsToDo(index.size());
 
     foreach (int idx, index) {
-        mitk::BaseData::Pointer data = nodes.at(idx)->GetData();
-        if (data) {
-            //Test if this data item is an image
-            mitk::Image::Pointer image = dynamic_cast<mitk::Image*>(data.GetPointer());
-            if (image) {
-                path = directory + mitk::IOUtil::GetDirectorySeparator() + "dcm-" + QString::number(ctr++) + ".nii";
-                mitk::IOUtil::Save(image, path.toStdString());
-                this->GetDataStorage()->Remove(nodes.at(idx));
-            } else
-                return;
-        } else
+        path = directory + mitk::IOUtil::GetDirectorySeparator() + "dcm-" + QString::number(ctr++) + ".nii";
+        successfulNitfi = CemrgCommonUtils::ConvertToNifti(nodes.at(idx)->GetData(), path);
+        if(successfulNitfi){
+            this->GetDataStorage()->Remove(nodes.at(idx));
+        } else{
             return;
+        }
         mitk::ProgressBar::GetInstance()->Progress();
     }//for
 

--- a/Version2.0/Plugins/kcl.cemrgapp.powertrans/src/internal/powertransViewPlot.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.powertrans/src/internal/powertransViewPlot.cpp
@@ -182,6 +182,7 @@ void powertransViewPlot::PlotData() {
     mitk::ProgressBar::GetInstance()->AddStepsToDo(1);
 
     //Define the reference mesh
+    mitk::Surface::Pointer refSurf;
     int segRatios[3] = {bas, mid, api};
     int pacingSegRatios[3] = {17, 33, 55}; // This give the AHA region from 50 - 50+1/3 in middle - Ie putting pacing site at 2/3 height
     strain = std::unique_ptr<CemrgStrains>(new CemrgStrains(directory, refMshNo));
@@ -192,12 +193,12 @@ void powertransViewPlot::PlotData() {
         mitk::ProgressBar::GetInstance()->Progress();
         return;
     }
-    mitk::Surface::Pointer refSurf;
 
     //Calculate y values of the plots
     flatPlotScalars.clear();
     plotValueVectors.clear();
     std::string plotType = m_Controls.comboBox->currentText().toStdString();
+
     if (plotType.compare("Squeez") == 0) {
         refSurf = strain->ReferenceAHA(lmNode, segRatios, false);
         for (int i=0; i<noFrames*smoothness; i++) {
@@ -251,6 +252,7 @@ void powertransViewPlot::PlotData() {
     //Visualise AHA plots
     HandleBullPlot(false);
     ColourAHASegments(m_Controls.horizontalSlider->value());
+
     //Visualise the curves plot
     HandleCurvPlot();
 
@@ -267,8 +269,6 @@ void powertransViewPlot::PlotData() {
             this->GetDataStorage()->Remove(nodeIt->Value());
         if (nodeIt->Value()->GetName().compare("Guideline 3") == 0)
             this->GetDataStorage()->Remove(nodeIt->Value());
-        //if (nodeIt->Value()->GetName().compare("Guideline 4") == 0)
-        //    this->GetDataStorage()->Remove(nodeIt->Value());
     }//_for
     mitk::DataNode::Pointer node = mitk::DataNode::New();
     node->SetProperty("scalar visibility", mitk::BoolProperty::New(true));
@@ -283,17 +283,6 @@ void powertransViewPlot::PlotData() {
         gNode->SetName("Guideline "+ std::to_string(i+1));
         gNode->SetData(guidelines.at(i));
         this->GetDataStorage()->Add(gNode, node);
-    }
-
-    /**
-     * STRAIN TEST
-     **/
-    if (false) {
-        for (unsigned int i=0; i<strain->temporaries.size(); i++) {
-            mitk::DataNode::Pointer aNode = mitk::DataNode::New();
-            aNode->SetData(strain->temporaries.at(i));
-            this->GetDataStorage()->Add(aNode, node);
-        }
     }
 
     this->BusyCursorOff();

--- a/Version2.0/Plugins/kcl.cemrgapp.powertrans/src/internal/powertransViewUIAhaInput.ui
+++ b/Version2.0/Plugins/kcl.cemrgapp.powertrans/src/internal/powertransViewUIAhaInput.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>120</height>
+    <height>128</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,10 +19,10 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
-  <property name="minimumSize">
+  <property name="maximumSize">
    <size>
-    <width>400</width>
-    <height>120</height>
+    <width>16777215</width>
+    <height>128</height>
    </size>
   </property>
   <property name="windowTitle">

--- a/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarClipperView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarClipperView.cpp
@@ -175,7 +175,7 @@ void AtrialScarClipperView::iniPreSurf() {
         if (image) {
 
             //Check seg node name
-            if (segNode->GetName().compare(fileName.left(fileName.length()-4).toStdString()) != 0) {
+            if (segNode->GetName().compare(fileName.left(fileName.lastIndexOf(QChar('.'))).toStdString()) != 0) {
                 QMessageBox::warning(NULL, "Attention", "Please select the loaded or created segmentation!");
                 this->GetSite()->GetPage()->ResetPerspective();
                 return;
@@ -394,7 +394,7 @@ void AtrialScarClipperView::ClipperImage() {
             if (image) {
 
                 //Check if the right segmentation
-                if (segNode->GetName().compare(fileName.left(fileName.length()-4).toStdString()) != 0) {
+                if (segNode->GetName().compare(fileName.left(fileName.lastIndexOf(QChar('.'))).toStdString()) != 0) {
                     QMessageBox::warning(NULL, "Attention", "Please select the loaded or created segmentation!");
                     return;
                 }//_if

--- a/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarClipperView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarClipperView.cpp
@@ -57,6 +57,8 @@ PURPOSE.  See the above copyright notices for more information.
 #include <vtkTextProperty.h>
 #include <vtkDecimatePro.h>
 #include <vtkGenericOpenGLRenderWindow.h>
+#include <vtkCleanPolyData.h>
+#include <vtkPolyDataNormals.h>
 
 // Qt
 #include <QMessageBox>
@@ -208,7 +210,7 @@ void AtrialScarClipperView::iniPreSurf() {
                 this->BusyCursorOn();
                 path = directory + mitk::IOUtil::GetDirectorySeparator() + "temp.nii";
                 mitk::IOUtil::Save(image, path.toStdString());
-                mitk::ProgressBar::GetInstance()->AddStepsToDo(4);
+                mitk::ProgressBar::GetInstance()->AddStepsToDo(3);
                 std::unique_ptr<CemrgCommandLine> cmd(new CemrgCommandLine());
                 QString output = cmd->ExecuteSurf(directory, path, "close", iter, th, blur, smth);
                 QMessageBox::information(NULL, "Attention", "Command Line Operations Finished!");
@@ -259,6 +261,7 @@ void AtrialScarClipperView::CtrLines() {
         //Retrieve centrelines and labels
         if (clipper->GetCentreLines().size() != 0)
             QMessageBox::information(NULL, "Attention", "You are using precomputed centrelines!");
+
         this->BusyCursorOn();
         for (unsigned int i=0; i<clipper->GetCentreLines().size(); i++) {
             if (i == 0) pickedSeedLabels.clear();
@@ -266,7 +269,6 @@ void AtrialScarClipperView::CtrLines() {
             vtkSmartPointer<vtkIntArray> lb = vtkIntArray::SafeDownCast(pd->GetFieldData()->GetAbstractArray("PickedSeedLabels"));
             pickedSeedLabels.push_back(lb->GetValue(0));
         }//_for
-        mitk::ProgressBar::GetInstance()->AddStepsToDo(pickedSeedLabels.size());
         bool successful = clipper->ComputeCtrLines(pickedSeedLabels, pickedSeedIds, m_Controls.checkBox->isChecked());
         m_Controls.checkBox->setChecked(clipper->GetCentreLinesOrientation());
         this->BusyCursorOff();
@@ -327,7 +329,6 @@ void AtrialScarClipperView::CtrPlanes() {
     } else {
 
         this->BusyCursorOn();
-        mitk::ProgressBar::GetInstance()->AddStepsToDo(pickedSeedLabels.size());
         bool successful = clipper->ComputeCtrLinesClippers(pickedSeedLabels);
         this->BusyCursorOff();
 
@@ -400,7 +401,6 @@ void AtrialScarClipperView::ClipperImage() {
 
                 this->BusyCursorOn();
                 this->GetDataStorage()->Remove(segNode);
-                mitk::ProgressBar::GetInstance()->AddStepsToDo(pickedSeedLabels.size());
                 clipper->ClipVeinsImage(pickedSeedLabels, image, false);
                 this->BusyCursorOff();
                 QMessageBox::information(NULL, "Attention", "Segmentation is now clipped!");
@@ -409,7 +409,6 @@ void AtrialScarClipperView::ClipperImage() {
                 QMessageBox::warning(NULL, "Attention", "Please select the loaded or created segmentation!");
                 return;
             }//_image
-
         } else {
             QMessageBox::warning(NULL, "Attention", "Please select the loaded or created segmentation!");
             return;

--- a/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarClipperView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarClipperView.cpp
@@ -268,6 +268,7 @@ void AtrialScarClipperView::CtrLines() {
         }//_for
         mitk::ProgressBar::GetInstance()->AddStepsToDo(pickedSeedLabels.size());
         bool successful = clipper->ComputeCtrLines(pickedSeedLabels, pickedSeedIds, m_Controls.checkBox->isChecked());
+        m_Controls.checkBox->setChecked(clipper->GetCentreLinesOrientation());
         this->BusyCursorOff();
 
         //Check for failure

--- a/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarClipperView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarClipperView.cpp
@@ -250,8 +250,10 @@ void AtrialScarClipperView::iniPreSurf() {
 void AtrialScarClipperView::CtrLines() {
 
     if (clipper->GetCentreLines().size() == 0 && pickedSeedLabels.size() == 0) {
+
         QMessageBox::warning(NULL, "Attention", "Please maske sure you have selected seeds!");
         return;
+
     } else {
 
         //Retrieve centrelines and labels
@@ -265,8 +267,15 @@ void AtrialScarClipperView::CtrLines() {
             pickedSeedLabels.push_back(lb->GetValue(0));
         }//_for
         mitk::ProgressBar::GetInstance()->AddStepsToDo(pickedSeedLabels.size());
-        clipper->ComputeCtrLines(pickedSeedLabels, pickedSeedIds, m_Controls.checkBox->isChecked());
+        bool successful = clipper->ComputeCtrLines(pickedSeedLabels, pickedSeedIds, m_Controls.checkBox->isChecked());
         this->BusyCursorOff();
+
+        //Check for failure
+        if (!successful) {
+            QMessageBox::critical(NULL, "Attention", "Computation of Centrelines Failed!");
+            return;
+        }//_if
+
     }//_if
 
     //Set surface opacity
@@ -310,14 +319,23 @@ void AtrialScarClipperView::CtrLines() {
 void AtrialScarClipperView::CtrPlanes() {
 
     if (clipper->GetCentreLines().size() == 0 || pickedSeedLabels.size() == 0) {
+
         QMessageBox::warning(NULL, "Attention", "Please maske sure you have computed centre lines!");
         return;
+
     } else {
 
         this->BusyCursorOn();
         mitk::ProgressBar::GetInstance()->AddStepsToDo(pickedSeedLabels.size());
-        clipper->ComputeCtrLinesClippers(pickedSeedLabels);
+        bool successful = clipper->ComputeCtrLinesClippers(pickedSeedLabels);
         this->BusyCursorOff();
+
+        //Check for failure
+        if (!successful) {
+            QMessageBox::critical(NULL, "Attention", "Computation of Clipper Planes Failed!");
+            return;
+        }//_if
+
     }//_if
 
     std::vector<vtkSmartPointer<vtkRegularPolygonSource>> ctrPlanes = clipper->GetCentreLinePolyPlanes();

--- a/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarView.cpp
@@ -64,6 +64,7 @@ PURPOSE.  See the above copyright notices for more information.
 #include <vtkDecimatePro.h>
 #include <vtkDataSetSurfaceFilter.h>
 #include <vtkTimerLog.h>
+#include <vtkPPolyDataNormals.h>
 
 // ITK
 #include <itkResampleImageFilter.h>
@@ -265,25 +266,25 @@ void AtrialScarView::ConvertNII() {
     bool successfulNitfi, resampleImage, reorientToRAI;
     resampleImage = true;
     reorientToRAI = true;
+
     this->BusyCursorOn();
     mitk::ProgressBar::GetInstance()->AddStepsToDo(index.size());
-
     foreach (int idx, index) {
         type = (ctr==0) ? "LGE":"MRA";
         path = directory + mitk::IOUtil::GetDirectorySeparator() + "dcm-" + type + "-" + seriesDscrps.at(idx).c_str() + ".nii";
         successfulNitfi = CemrgCommonUtils::ConvertToNifti(nodes.at(idx)->GetData(), path, resampleImage, reorientToRAI);
-        if(successfulNitfi){
+        if (successfulNitfi) {
             this->GetDataStorage()->Remove(nodes.at(idx));
             std::string key = "dicom.series.SeriesDescription";
             mitk::DataStorage::SetOfObjects::Pointer set = mitk::IOUtil::Load(path.toStdString(), *this->GetDataStorage());
             set->Begin().Value()->GetData()->GetPropertyList()->SetStringProperty(key.c_str(), seriesDscrps.at(idx).c_str());
             ctr++;
-        } else{
+        } else {
+            mitk::ProgressBar::GetInstance()->Progress(index.size());
             return;
-        }
+        }//_if
         mitk::ProgressBar::GetInstance()->Progress();
     }//for
-
     nodes.clear();
     this->BusyCursorOff();
 
@@ -701,21 +702,21 @@ void AtrialScarView::AutomaticAnalysis() {
             surfer->Update();
 
             MITK_INFO << "[...][9.2] Cleaning...";
-            vtkSmartPointer<vtkCleanPolyData> cleaner = vtkSmartPointer<vtkCleanPolyData>::New();
-            cleaner->SetInputConnection(surfer->GetOutputPort());
-            cleaner->Update();
+            vtkSmartPointer<vtkCleanPolyData> clean = vtkSmartPointer<vtkCleanPolyData>::New();
+            clean->SetInputConnection(surfer->GetOutputPort());
+            clean->Update();
 
             MITK_INFO << "[...][9.3] Largest region...";
             vtkSmartPointer<vtkPolyDataConnectivityFilter> lrgRegion = vtkSmartPointer<vtkPolyDataConnectivityFilter>::New();
-            lrgRegion->SetInputConnection(cleaner->GetOutputPort());
+            lrgRegion->SetInputConnection(clean->GetOutputPort());
             lrgRegion->SetExtractionModeToLargestRegion();
             lrgRegion->Update();
-            cleaner = vtkSmartPointer<vtkCleanPolyData>::New();
-            cleaner->SetInputConnection(lrgRegion->GetOutputPort());
-            cleaner->Update();
+            clean = vtkSmartPointer<vtkCleanPolyData>::New();
+            clean->SetInputConnection(lrgRegion->GetOutputPort());
+            clean->Update();
 
             MITK_INFO << ("[...][9.4] Saving to file: " + output2).toStdString();
-            LAShell->SetVtkPolyData(cleaner->GetOutput());
+            LAShell->SetVtkPolyData(clean->GetOutput());
             mitk::IOUtil::Save(LAShell, output2.toStdString());
 
             MITK_INFO << "[AUTOMATIC_ANALYSIS][10] Scar projection";
@@ -863,6 +864,7 @@ void AtrialScarView::SegmentIMGS() {
                     std::unique_ptr<CemrgCommandLine> cmd(new CemrgCommandLine());
                     cmd->SetUseDockerContainers(true);
                     QString cnnPath = cmd->DockerCemrgNetPrediction(mraPath);
+                    mitk::ProgressBar::GetInstance()->Progress();
 
                     //Clean prediction
                     using ImageTypeCHAR = itk::Image<short, 3>;
@@ -885,7 +887,6 @@ void AtrialScarView::SegmentIMGS() {
                     mitk::IOUtil::Save(segImage, cnnPath.toStdString());
                     mitk::IOUtil::Load(cnnPath.toStdString(), *this->GetDataStorage());
                     remove(mraPath.toStdString().c_str());
-
                     fileName = "LA.nii";
                     QMessageBox::information(NULL, "Attention", "Command Line Operations Finished!");
                     mitk::ProgressBar::GetInstance()->Progress();
@@ -1025,6 +1026,7 @@ void AtrialScarView::Register() {
             cmd->SetUseDockerContainers(_useDockerInPlugin);
             cmd->ExecuteRegistration(directory, lge, mra);
             QMessageBox::information(NULL, "Attention", "Command Line Operations Finished!");
+            mitk::ProgressBar::GetInstance()->Progress();
             this->BusyCursorOff();
 
         } else {
@@ -1089,6 +1091,7 @@ void AtrialScarView::Transform() {
                 cmd->SetUseDockerContainers(_useDockerInPlugin);
                 cmd->ExecuteTransformation(directory, pathTemp.right(8), regFileName);
                 QMessageBox::information(NULL, "Attention", "Command Line Operations Finished!");
+                mitk::ProgressBar::GetInstance()->Progress();
                 this->BusyCursorOff();
 
                 //Load the new segementation
@@ -1198,7 +1201,7 @@ void AtrialScarView::CreateSurf() {
                 this->BusyCursorOn();
                 pathTemp = directory + mitk::IOUtil::GetDirectorySeparator() + "temp.nii";
                 mitk::IOUtil::Save(image, pathTemp.toStdString());
-                mitk::ProgressBar::GetInstance()->AddStepsToDo(4);
+                mitk::ProgressBar::GetInstance()->AddStepsToDo(3);
                 std::unique_ptr<CemrgCommandLine> cmd(new CemrgCommandLine());
                 cmd->SetUseDockerContainers(_useDockerInPlugin);
                 path = cmd->ExecuteSurf(directory, pathTemp, "close", iter, th, blur, smth);
@@ -1505,13 +1508,10 @@ void AtrialScarView::ScarMap() {
                     //Projection
                     scar->SetScarSegImage(scarSegImg);
                     mitk::Surface::Pointer shell = scar->Scar3D(directory.toStdString(), image);
-                    mitk::DataNode::Pointer node = CemrgCommonUtils::AddToStorage(
-                                shell, (meType + "Scar3D").toStdString(), this->GetDataStorage());
-                    mitk::ProgressBar::GetInstance()->Progress();
+                    mitk::DataNode::Pointer node = CemrgCommonUtils::AddToStorage(shell, (meType + "Scar3D").toStdString(), this->GetDataStorage());
 
                     MITK_INFO << "Saving debug scar map labels.";
                     scar->SaveScarDebugImage(meType + "_debugSCAR.nii", directory);
-                    // m_Controls.button_debugscar->setVisible(true);
 
                     //Check to remove the previous mesh node
                     sob = this->GetDataStorage()->GetAll();
@@ -1519,6 +1519,7 @@ void AtrialScarView::ScarMap() {
                         if (nodeIt->Value()->GetName().find("-Mesh") != nodeIt->Value()->GetName().npos)
                             this->GetDataStorage()->Remove(nodeIt->Value());
 
+                    //LUT setup
                     mitk::LookupTable::Pointer scarLut = mitk::LookupTable::New();
                     vtkSmartPointer<vtkLookupTable> lut = vtkSmartPointer<vtkLookupTable>::New();
                     lut->SetTableRange(0, scar->GetMaxScalar());
@@ -1538,6 +1539,7 @@ void AtrialScarView::ScarMap() {
                     QString path = directory + mitk::IOUtil::GetDirectorySeparator() + name + "-" + meType + "Scar.vtk";
                     mitk::IOUtil::Save(shell, path.toStdString());
 
+                    mitk::ProgressBar::GetInstance()->Progress();
                     this->BusyCursorOff();
                     inputs->deleteLater();
 

--- a/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarView.cpp
@@ -682,7 +682,7 @@ void AtrialScarView::AutomaticAnalysis() {
             mitk::IOUtil::Save(mitk::ImportItkImage(mvImage), (direct + "/prodMVI.nii").toStdString());
 
             // Make vtk of prodMVI
-            QString mviShellPath = cmd->ExecuteSurf(direct, "prodMVI.nii", "dilate", 1, 0.5, 0, 10);
+            QString mviShellPath = cmd->ExecuteSurf(direct, "prodMVI.nii", "close", 1, 0.5, 0, 10);
             // Implement code from command line tool
             mitk::Surface::Pointer ClipperSurface = mitk::IOUtil::Load<mitk::Surface>(mviShellPath.toStdString());
             vtkSmartPointer<vtkImplicitPolyDataDistance> implicitFn = vtkSmartPointer<vtkImplicitPolyDataDistance>::New();

--- a/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarView.cpp
@@ -533,7 +533,6 @@ void AtrialScarView::AutomaticAnalysis() {
             MITK_INFO << ("[...][3.1] Saved file: "+segCleanPath).toStdString();
 
             MITK_INFO << "[AUTOMATIC_ANALYSIS][4] Vein clipping mesh";
-            cmd->ExecuteTouch(direct+mitk::IOUtil::GetDirectorySeparator() + "segmentation.vtk");
             QString output1 = cmd->ExecuteSurf(direct, segCleanPath, "close", 1, .5, 0, 10);
             mitk::Surface::Pointer shell = mitk::IOUtil::Load<mitk::Surface>(output1.toStdString());
             vtkSmartPointer<vtkDecimatePro> deci = vtkSmartPointer<vtkDecimatePro>::New();

--- a/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarView.cpp
@@ -161,7 +161,7 @@ void AtrialScarView::LoadDICOM() {
                                    "Use alternative DICOM reader?", QMessageBox::Yes, QMessageBox::No);
 #endif
 
-    if(reply1 == QMessageBox::Yes) {
+    if (reply1 == QMessageBox::Yes) {
 
         QString dicomFolder = QFileDialog::getExistingDirectory(NULL, "Open folder with DICOMs.", mitk::IOUtil::GetProgramPath().c_str(), QFileDialog::ShowDirsOnly|QFileDialog::DontUseNativeDialog);
         std::unique_ptr<CemrgCommandLine> cmd(new CemrgCommandLine());
@@ -184,27 +184,33 @@ void AtrialScarView::LoadDICOM() {
                     thisFile = niftiFiles.at(ix);
                     if (thisFile.contains(".nii", Qt::CaseSensitive)) {
                         if (thisFile.contains("lge", Qt::CaseInsensitive) ||  thisFile.contains("mra", Qt::CaseInsensitive)) {
+
                             path = niftiFolder.absolutePath() + mitk::IOUtil::GetDirectorySeparator() + thisFile;
                             mitk::Image::Pointer image = mitk::IOUtil::Load<mitk::Image>(path.toStdString());
                             std::string key = "dicom.series.SeriesDescription";
                             mitk::DataStorage::SetOfObjects::Pointer set = mitk::IOUtil::Load(path.toStdString(), *this->GetDataStorage());
                             set->Begin().Value()->GetData()->GetPropertyList()->SetStringProperty(key.c_str(), thisFile.left(thisFile.length()-4).toStdString().c_str());
+
                         }//_if
                     }//_if
-
                 }//_for
 
             } else {
+
                 MITK_WARN << "Problem with conversion.";
                 QMessageBox::warning(NULL, "Attention", "Problem with alternative conversion. Try MITK Dicom editor?");
                 return;
-            }
+
+            }//_if
         }//_if
+
     } else {
+
         MITK_INFO << "Using MITK DICOM editor";
         QString editor_id = "org.mitk.editors.dicomeditor";
         berry::IEditorInput::Pointer input(new berry::FileEditorInput(QString()));
         this->GetSite()->GetPage()->OpenEditor(input, editor_id);
+
     }//_if
 }
 
@@ -936,7 +942,7 @@ void AtrialScarView::NodeAdded(const mitk::DataNode* node) {
                 fileName = QInputDialog::getText(
                             NULL, tr("Save Segmentation As"), tr("File Name:"), QLineEdit::Normal, fileName, &ok);
                 if (ok && !fileName.isEmpty() && fileName.endsWith(".nii")) {
-                    segNode->SetName(fileName.left(fileName.length()-4).toStdString());
+                    segNode->SetName(fileName.left(fileName.lastIndexOf(QChar('.'))).toStdString());
                     path = directory + mitk::IOUtil::GetDirectorySeparator() + fileName;
                     mitk::IOUtil::Save(image, path.toStdString());
                 } else {
@@ -1070,7 +1076,6 @@ void AtrialScarView::Transform() {
 
             //Check seg node name
             QString segNodeTest = QString::fromStdString(segNode->GetName()) + ".nii";
-            // if (segNode->GetName().compare(fileName.left(fileName.length()-4).toStdString()) != 0) {
             if (!fileName.contains(segNodeTest, Qt::CaseSensitive)) {
                 MITK_WARN << ("[Transform] Problem with filename: " + fileName).toStdString();
                 MITK_INFO << "[...][warning] segNode: " + segNode->GetName();
@@ -1080,7 +1085,7 @@ void AtrialScarView::Transform() {
 
             bool ok;
             QString regFileName;
-            regFileName = fileName.left(fileName.length()-4) + "-reg.nii";
+            regFileName = fileName.left(fileName.lastIndexOf(QChar('.'))) + "-reg.nii";
             regFileName = QInputDialog::getText(NULL, tr("Save Registration As"), tr("File Name:"), QLineEdit::Normal, regFileName, &ok);
             if (ok && !regFileName.isEmpty() && regFileName.endsWith(".nii")) {
 
@@ -1171,7 +1176,7 @@ void AtrialScarView::CreateSurf() {
         if (image) {
 
             //Check seg node name
-            if (segNode->GetName().compare(fileName.left(fileName.length()-4).toStdString()) != 0) {
+            if (segNode->GetName().compare(fileName.left(fileName.lastIndexOf(QChar('.'))).toStdString()) != 0) {
                 QMessageBox::warning(NULL, "Attention", "Please select the loaded or created segmentation!");
                 return;
             }//_if
@@ -1270,7 +1275,8 @@ void AtrialScarView::SelectLandmarks() {
             return;
         }//_if
 
-        if (!RequestProjectDirectoryFromUser()) return; // if the path was chosen incorrectly -> returns.
+        //If the path was chosen incorrectly returns
+        if (!RequestProjectDirectoryFromUser()) return;
 
         //Reset the button
         m_Controls.button_z_1->setText("Select Landmarks");
@@ -1313,7 +1319,7 @@ void AtrialScarView::SelectLandmarks() {
         for (mitk::DataStorage::SetOfObjects::ConstIterator nodeIt = sob->Begin(); nodeIt != sob->End(); ++nodeIt)
             if (nodeIt->Value()->GetName().find("MVClipper") != nodeIt->Value()->GetName().npos)
                 this->GetDataStorage()->Remove(nodeIt->Value());
-        CemrgCommonUtils::AddToStorage(mvClipper, "MVClipper", this->GetDataStorage());
+        CemrgCommonUtils::AddToStorage(mvClipper, "MVClipper", this->GetDataStorage(), false);
         sob = this->GetDataStorage()->GetAll();
         for (mitk::DataStorage::SetOfObjects::ConstIterator nodeIt = sob->Begin(); nodeIt != sob->End(); ++nodeIt) {
             if (nodeIt->Value()->GetName().find("MVClipper") != nodeIt->Value()->GetName().npos) {
@@ -1352,7 +1358,7 @@ void AtrialScarView::ClipMitralValve() {
         QMessageBox::critical(NULL, "Attention", "No mesh was found in the project directory!");
         return;
     }//_if
-    QString orgP = path.left(path.length()-4) + "-Original.vtk";
+    QString orgP = path.left(path.lastIndexOf(QChar('.'))) + "-Original.vtk";
     mitk::IOUtil::Save(mitk::IOUtil::Load<mitk::Surface>(path.toStdString()), orgP.toStdString());
 
     /*
@@ -1377,7 +1383,7 @@ void AtrialScarView::ClipMitralValve() {
         if (nodeIt->Value()->GetName().find("MVClipper") != nodeIt->Value()->GetName().npos)
             this->GetDataStorage()->Remove(nodeIt->Value());
     }//_for
-    CemrgCommonUtils::AddToStorage(surface, "MVClipped-Mesh", this->GetDataStorage());
+    CemrgCommonUtils::AddToStorage(surface, "MVClipped-Mesh", this->GetDataStorage(), false);
 
     //Reverse coordination of surface for writing MIRTK style
     mitk::Surface::Pointer surfCloned = surface->Clone();
@@ -1500,7 +1506,7 @@ void AtrialScarView::ScarMap() {
                     scarSegImg = mitk::ImportItkImage(resampleFilter->GetOutput());
 
                     //Update datamanger
-                    std::string nodeSegImgName = fileName.left(fileName.length()-4).toStdString();
+                    std::string nodeSegImgName = fileName.left(fileName.lastIndexOf(QChar('.'))).toStdString();
                     mitk::DataStorage::SetOfObjects::ConstPointer sob = this->GetDataStorage()->GetAll();
                     for (mitk::DataStorage::SetOfObjects::ConstIterator nodeIt = sob->Begin(); nodeIt != sob->End(); ++nodeIt)
                         if (nodeIt->Value()->GetName().find(nodeSegImgName) != nodeIt->Value()->GetName().npos)

--- a/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarView.cpp
@@ -1823,7 +1823,7 @@ bool AtrialScarView::RequestProjectDirectoryFromUser(){
             MITK_WARN << "Please select a project directory with no spaces in the path!";
             QMessageBox::warning(NULL, "Attention", "Please select a project directory with no spaces in the path!");
             directory = QString();
-            bool succesfulAssignment = false;
+            succesfulAssignment = false;
         }//_if
     } else {
         MITK_INFO << ("Project directory already set: " + directory).toStdString();

--- a/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarView.cpp
@@ -262,33 +262,25 @@ void AtrialScarView::ConvertNII() {
     //Convert to Nifti
     int ctr = 0;
     QString path, type;
+    bool successfulNitfi, resampleImage, reorientToRAI;
+    resampleImage = true;
+    reorientToRAI = true;
     this->BusyCursorOn();
     mitk::ProgressBar::GetInstance()->AddStepsToDo(index.size());
 
     foreach (int idx, index) {
-        mitk::BaseData::Pointer data = nodes.at(idx)->GetData();
-        if (data) {
-            //Test if this data item is an image
-            mitk::Image::Pointer image = dynamic_cast<mitk::Image*>(data.GetPointer());
-            if (image) {
-                MITK_INFO << "[ConvertNII] Converting DICOMs to nifti";
-
-                //Resample image to be iso
-                image = CemrgCommonUtils::IsoImageResampling(image);
-
-                type = (ctr==0) ? "LGE":"MRA";
-                path = directory + mitk::IOUtil::GetDirectorySeparator() + "dcm-" + type + "-" + seriesDscrps.at(idx).c_str() + ".nii";
-                mitk::IOUtil::Save(image, path.toStdString());
-                this->GetDataStorage()->Remove(nodes.at(idx));
-
-                std::string key = "dicom.series.SeriesDescription";
-                mitk::DataStorage::SetOfObjects::Pointer set = mitk::IOUtil::Load(path.toStdString(), *this->GetDataStorage());
-                set->Begin().Value()->GetData()->GetPropertyList()->SetStringProperty(key.c_str(), seriesDscrps.at(idx).c_str());
-                ctr++;
-            } else
-                return;
-        } else
+        type = (ctr==0) ? "LGE":"MRA";
+        path = directory + mitk::IOUtil::GetDirectorySeparator() + "dcm-" + type + "-" + seriesDscrps.at(idx).c_str() + ".nii";
+        successfulNitfi = CemrgCommonUtils::ConvertToNifti(nodes.at(idx)->GetData(), path, resampleImage, reorientToRAI);
+        if(successfulNitfi){
+            this->GetDataStorage()->Remove(nodes.at(idx));
+            std::string key = "dicom.series.SeriesDescription";
+            mitk::DataStorage::SetOfObjects::Pointer set = mitk::IOUtil::Load(path.toStdString(), *this->GetDataStorage());
+            set->Begin().Value()->GetData()->GetPropertyList()->SetStringProperty(key.c_str(), seriesDscrps.at(idx).c_str());
+            ctr++;
+        } else{
             return;
+        }
         mitk::ProgressBar::GetInstance()->Progress();
     }//for
 

--- a/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarView.cpp
@@ -152,60 +152,64 @@ void AtrialScarView::OnSelectionChanged(
         berry::IWorkbenchPart::Pointer /*source*/, const QList<mitk::DataNode::Pointer>& /*nodes*/) {
 }
 
-
 void AtrialScarView::LoadDICOM() {
+
     int reply1 = QMessageBox::No;
 #if defined(__APPLE__)
     MITK_INFO << "Ask user about alternative DICOM reader";
     reply1 = QMessageBox::question(NULL, "Question",
                                    "Use alternative DICOM reader?", QMessageBox::Yes, QMessageBox::No);
 #endif
-    if(reply1 == QMessageBox::Yes){
-        QString dicomFolder = QFileDialog::getExistingDirectory(NULL, "Open folder with DICOMs.", mitk::IOUtil::GetProgramPath().c_str(), QFileDialog::ShowDirsOnly|QFileDialog::DontUseNativeDialog);
 
+    if(reply1 == QMessageBox::Yes) {
+
+        QString dicomFolder = QFileDialog::getExistingDirectory(NULL, "Open folder with DICOMs.", mitk::IOUtil::GetProgramPath().c_str(), QFileDialog::ShowDirsOnly|QFileDialog::DontUseNativeDialog);
         std::unique_ptr<CemrgCommandLine> cmd(new CemrgCommandLine());
         QString tmpNiftiFolder = cmd->DockerDicom2Nifti(dicomFolder);
-        if(tmpNiftiFolder.compare("ERROR_IN_PROCESSING") != 0){
+
+        if (tmpNiftiFolder.compare("ERROR_IN_PROCESSING") != 0) {
+
             // add results in NIIs folder to Data Manager
             MITK_INFO << ("Conversion succesful. Intermediate NII folder: " + tmpNiftiFolder).toStdString();
             QMessageBox::information(NULL, "Information", "Conversion successful, press the Process Images button to continue.");
-
             QDir niftiFolder(tmpNiftiFolder);
             QStringList niftiFiles = niftiFolder.entryList();
 
-            if(niftiFiles.size()>0){
+            if (niftiFiles.size()>0) {
+
                 QString thisFile, path;
-                for(int ix=0; ix<niftiFiles.size(); ix++){
+                for(int ix=0; ix<niftiFiles.size(); ix++) {
+
                     // load here files
                     thisFile = niftiFiles.at(ix);
-                    if(thisFile.contains(".nii", Qt::CaseSensitive)){
-                        if(thisFile.contains("lge", Qt::CaseInsensitive) ||  thisFile.contains("mra", Qt::CaseInsensitive)){
+                    if (thisFile.contains(".nii", Qt::CaseSensitive)) {
+                        if (thisFile.contains("lge", Qt::CaseInsensitive) ||  thisFile.contains("mra", Qt::CaseInsensitive)) {
                             path = niftiFolder.absolutePath() + mitk::IOUtil::GetDirectorySeparator() + thisFile;
-
                             mitk::Image::Pointer image = mitk::IOUtil::Load<mitk::Image>(path.toStdString());
-
                             std::string key = "dicom.series.SeriesDescription";
                             mitk::DataStorage::SetOfObjects::Pointer set = mitk::IOUtil::Load(path.toStdString(), *this->GetDataStorage());
                             set->Begin().Value()->GetData()->GetPropertyList()->SetStringProperty(key.c_str(), thisFile.left(thisFile.length()-4).toStdString().c_str());
-                        }
+                        }//_if
+                    }//_if
 
-                    }
-                }
-            } else{
+                }//_for
+
+            } else {
                 MITK_WARN << "Problem with conversion.";
                 QMessageBox::warning(NULL, "Attention", "Problem with alternative conversion. Try MITK Dicom editor?");
                 return;
             }
-        }
+        }//_if
     } else {
         MITK_INFO << "Using MITK DICOM editor";
         QString editor_id = "org.mitk.editors.dicomeditor";
         berry::IEditorInput::Pointer input(new berry::FileEditorInput(QString()));
         this->GetSite()->GetPage()->OpenEditor(input, editor_id);
-    }
+    }//_if
 }
 
 void AtrialScarView::ProcessIMGS() {
+
     //Toggle visibility of buttons
     if (m_Controls.button_2_1->isVisible()){
         m_Controls.button_2_1->setVisible(false);
@@ -1822,11 +1826,13 @@ void AtrialScarView::Reset(bool allItems) {
     this->GetSite()->GetPage()->ResetPerspective();
 }
 
-// helper functions
-bool AtrialScarView::RequestProjectDirectoryFromUser(){
+bool AtrialScarView::RequestProjectDirectoryFromUser() {
+
     bool succesfulAssignment = true;
+
     //Ask the user for a dir to store data
     if (directory.isEmpty()) {
+
         MITK_INFO << "Directory is empty. Requesting user for directory.";
         directory = QFileDialog::getExistingDirectory(
                     NULL, "Open Project Directory", mitk::IOUtil::GetProgramPath().c_str(),
@@ -1838,9 +1844,10 @@ bool AtrialScarView::RequestProjectDirectoryFromUser(){
             directory = QString();
             succesfulAssignment = false;
         }//_if
+
     } else {
         MITK_INFO << ("Project directory already set: " + directory).toStdString();
-    }
+    }//_if
 
     return succesfulAssignment;
 }

--- a/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarView.cpp
@@ -179,17 +179,7 @@ void AtrialScarView::ConvertNII() {
         return;
     }//_if
 
-    //Ask the user for a dir to store data
-    if (directory.isEmpty()) {
-        directory = QFileDialog::getExistingDirectory(
-                    NULL, "Open Project Directory", mitk::IOUtil::GetProgramPath().c_str(),
-                    QFileDialog::ShowDirsOnly|QFileDialog::DontUseNativeDialog);
-        if (directory.isEmpty() || directory.simplified().contains(" ")) {
-            QMessageBox::warning(NULL, "Attention", "Please select a project directory with no spaces in the path!");
-            directory = QString();
-            return;
-        }//_if
-    }
+    if (!RequestProjectDirectoryFromUser()) return; // if the path was chosen incorrectly -> returns.
 
     //Order dicoms based on their type
     std::vector<int> indexNodes;
@@ -349,8 +339,7 @@ void AtrialScarView::AutomaticAnalysis() {
 
     QDirIterator searchit(direct, QDirIterator::Subdirectories);
 
-    if (debugging)
-        MITK_INFO << "[DEBUG] Searching for CEMRGNET output";
+    MITK_INFO(debugging) << "[DEBUG] Searching for CEMRGNET output";
 
     while(searchit.hasNext()) {
         QFileInfo searchfinfo(searchit.next());
@@ -817,18 +806,7 @@ void AtrialScarView::AutomaticAnalysis() {
 
 void AtrialScarView::SegmentIMGS() {
 
-    //Ask the user for a dir to store data
-    if (directory.isEmpty()) {
-		MITK_INFO << "Directory is empty. Requesting user for directory.";
-        directory = QFileDialog::getExistingDirectory(
-                    NULL, "Open Project Directory", mitk::IOUtil::GetProgramPath().c_str(),
-                    QFileDialog::ShowDirsOnly|QFileDialog::DontUseNativeDialog);
-        if (directory.isEmpty() || directory.simplified().contains(" ")) {
-            QMessageBox::warning(NULL, "Attention", "Please select a project directory with no spaces in the path!");
-            directory = QString();
-            return;
-        }//_if
-    }
+    if (!RequestProjectDirectoryFromUser()) return; // if the path was chosen incorrectly -> returns.
 
     int reply1 = QMessageBox::question(
                 NULL, "Question", "Do you have a segmentation to load?", QMessageBox::Yes, QMessageBox::No);
@@ -928,17 +906,7 @@ void AtrialScarView::NodeAdded(const mitk::DataNode* node) {
         mitk::DataStorage::SetOfObjects::ConstIterator itSeg = nodes->Begin();
         mitk::DataNode::Pointer segNode = itSeg->Value();
 
-        //Ask the user for a dir to store data
-        if (directory.isEmpty()) {
-            directory = QFileDialog::getExistingDirectory(
-                        NULL, "Open Project Directory", mitk::IOUtil::GetProgramPath().c_str(),
-                        QFileDialog::ShowDirsOnly|QFileDialog::DontUseNativeDialog);
-            if (directory.isEmpty() || directory.simplified().contains(" ")) {
-                QMessageBox::warning(NULL, "Attention", "Please select a project directory with no spaces in the path!");
-                directory = QString();
-                return;
-            }//_if
-        }
+        if (!RequestProjectDirectoryFromUser()) return; // if the path was chosen incorrectly -> returns.
 
         //Find the selected node
         QString path;
@@ -1007,17 +975,7 @@ void AtrialScarView::Register() {
         return;
     }
 
-    //Ask the user for a dir to store data
-    if (directory.isEmpty()) {
-        directory = QFileDialog::getExistingDirectory(
-                    NULL, "Open Project Directory", mitk::IOUtil::GetProgramPath().c_str(),
-                    QFileDialog::ShowDirsOnly|QFileDialog::DontUseNativeDialog);
-        if (directory.isEmpty() || directory.simplified().contains(" ")) {
-            QMessageBox::warning(NULL, "Attention", "Please select a project directory with no spaces in the path!");
-            directory = QString();
-            return;
-        }//_if
-    }
+    if (!RequestProjectDirectoryFromUser()) return; // if the path was chosen incorrectly -> returns.
 
     //Sort the two images
     QString lge, mra;
@@ -1083,17 +1041,7 @@ void AtrialScarView::Transform() {
         return;
     }
 
-    //Ask the user for a dir to store data
-    if (directory.isEmpty()) {
-        directory = QFileDialog::getExistingDirectory(
-                    NULL, "Open Project Directory", mitk::IOUtil::GetProgramPath().c_str(),
-                    QFileDialog::ShowDirsOnly|QFileDialog::DontUseNativeDialog);
-        if (directory.isEmpty() || directory.simplified().contains(" ")) {
-            QMessageBox::warning(NULL, "Attention", "Please select a project directory with no spaces in the path!");
-            directory = QString();
-            return;
-        }//_if
-    }
+    if (!RequestProjectDirectoryFromUser()) return; // if the path was chosen incorrectly -> returns.
 
     //Find the selected node
     QString path, pathTemp;
@@ -1160,17 +1108,7 @@ void AtrialScarView::Transform() {
 
 void AtrialScarView::ClipPVeins() {
 
-    //Ask the user for a dir to store data
-    if (directory.isEmpty()) {
-        directory = QFileDialog::getExistingDirectory(
-                    NULL, "Open Project Directory", mitk::IOUtil::GetProgramPath().c_str(),
-                    QFileDialog::ShowDirsOnly|QFileDialog::DontUseNativeDialog);
-        if (directory.isEmpty() || directory.simplified().contains(" ")) {
-            QMessageBox::warning(NULL, "Attention", "Please select a project directory with no spaces in the path!");
-            directory = QString();
-            return;
-        }//_if
-    }
+    if (!RequestProjectDirectoryFromUser()) return; // if the path was chosen incorrectly -> returns.
 
     //Show the plugin
     this->GetSite()->GetPage()->ResetPerspective();
@@ -1179,20 +1117,8 @@ void AtrialScarView::ClipPVeins() {
 }
 
 void AtrialScarView::ExtraCalcs() {
-
-    std::cout << "[INFO] Calling view org.mitk.views.scarcalculations" << std::endl;
-
-    //Ask the user for a dir to store data
-    if (directory.isEmpty()) {
-        directory = QFileDialog::getExistingDirectory(
-                    NULL, "Open Patient's directory", mitk::IOUtil::GetProgramPath().c_str(),
-                    QFileDialog::ShowDirsOnly|QFileDialog::DontUseNativeDialog);
-        if (directory.isEmpty() || directory.simplified().contains(" ")) {
-            QMessageBox::warning(NULL, "Attention", "Please select a project directory with no spaces in the path!");
-            directory = QString();
-            return;
-        }//_if
-    }
+    MITK_INFO << "[INFO] Calling view org.mitk.views.scarcalculations" << std::endl;
+    if (!RequestProjectDirectoryFromUser()) return; // if the path was chosen incorrectly -> returns.
 
     //Show the plugin
     this->GetSite()->GetPage()->ResetPerspective();
@@ -1216,17 +1142,7 @@ void AtrialScarView::CreateSurf() {
         return;
     }
 
-    //Ask the user for a dir to store data
-    if (directory.isEmpty()) {
-        directory = QFileDialog::getExistingDirectory(
-                    NULL, "Open Project Directory", mitk::IOUtil::GetProgramPath().c_str(),
-                    QFileDialog::ShowDirsOnly|QFileDialog::DontUseNativeDialog);
-        if (directory.isEmpty() || directory.simplified().contains(" ")) {
-            QMessageBox::warning(NULL, "Attention", "Please select a project directory with no spaces in the path!");
-            directory = QString();
-            return;
-        }//_if
-    }
+    if (!RequestProjectDirectoryFromUser()) return; // if the path was chosen incorrectly -> returns.
 
     //Find the selected node
     QString path, pathTemp;
@@ -1337,17 +1253,7 @@ void AtrialScarView::SelectLandmarks() {
             return;
         }//_if
 
-        //Ask the user for a dir to store data
-        if (directory.isEmpty()) {
-            directory = QFileDialog::getExistingDirectory(
-                        NULL, "Open Project Directory", mitk::IOUtil::GetProgramPath().c_str(),
-                        QFileDialog::ShowDirsOnly|QFileDialog::DontUseNativeDialog);
-            if (directory.isEmpty() || directory.simplified().contains(" ")) {
-                QMessageBox::warning(NULL, "Attention", "Please select a project directory with no spaces in the path!");
-                directory = QString();
-                return;
-            }//_if
-        }
+        if (!RequestProjectDirectoryFromUser()) return; // if the path was chosen incorrectly -> returns.
 
         //Reset the button
         m_Controls.button_z_1->setText("Select Landmarks");
@@ -1420,17 +1326,7 @@ void AtrialScarView::ClipMitralValve() {
         return;
     }//_if
 
-    //Ask the user for a dir to store data
-    if (directory.isEmpty()) {
-        directory = QFileDialog::getExistingDirectory(
-                    NULL, "Open Project Directory", mitk::IOUtil::GetProgramPath().c_str(),
-                    QFileDialog::ShowDirsOnly|QFileDialog::DontUseNativeDialog);
-        if (directory.isEmpty() || directory.simplified().contains(" ")) {
-            QMessageBox::warning(NULL, "Attention", "Please select a project directory with no spaces in the path!");
-            directory = QString();
-            return;
-        }//_if
-    }
+    if (!RequestProjectDirectoryFromUser()) return; // if the path was chosen incorrectly -> returns.
 
     //Read in and copy
     QString path = directory + mitk::IOUtil::GetDirectorySeparator() + "segmentation.vtk";
@@ -1493,17 +1389,7 @@ void AtrialScarView::ScarMap() {
         return;
     }
 
-    //Ask the user for a dir to store data
-    if (directory.isEmpty()) {
-        directory = QFileDialog::getExistingDirectory(
-                    NULL, "Open Project Directory", mitk::IOUtil::GetProgramPath().c_str(),
-                    QFileDialog::ShowDirsOnly|QFileDialog::DontUseNativeDialog);
-        if (directory.isEmpty() || directory.simplified().contains(" ")) {
-            QMessageBox::warning(NULL, "Attention", "Please select a project directory with no spaces in the path!");
-            directory = QString();
-            return;
-        }//_if
-    }
+    if (!RequestProjectDirectoryFromUser()) return; // if the path was chosen incorrectly -> returns.
 
     //Check for mesh in the project directory
     try {
@@ -1686,17 +1572,7 @@ void AtrialScarView::Threshold() {
         return;
     }
 
-    //Ask the user for a dir to store data
-    if (directory.isEmpty()) {
-        directory = QFileDialog::getExistingDirectory(
-                    NULL, "Open Project Directory", mitk::IOUtil::GetProgramPath().c_str(),
-                    QFileDialog::ShowDirsOnly|QFileDialog::DontUseNativeDialog);
-        if (directory.isEmpty() || directory.simplified().contains(" ")) {
-            QMessageBox::warning(NULL, "Attention", "Please select a project directory with no spaces in the path!");
-            directory = QString();
-            return;
-        }//_if
-    }
+    if (!RequestProjectDirectoryFromUser()) return; // if the path was chosen incorrectly -> returns.
 
     //Find the selected node
     double mean = 0.0, stdv = 0.0;
@@ -1818,17 +1694,7 @@ void AtrialScarView::Threshold() {
 
 void AtrialScarView::Sphericity() {
 
-    //Ask the user for a dir to store data
-    if (directory.isEmpty()) {
-        directory = QFileDialog::getExistingDirectory(
-                    NULL, "Open Project Directory", mitk::IOUtil::GetProgramPath().c_str(),
-                    QFileDialog::ShowDirsOnly|QFileDialog::DontUseNativeDialog);
-        if (directory.isEmpty() || directory.simplified().contains(" ")) {
-            QMessageBox::warning(NULL, "Attention", "Please select a project directory with no spaces in the path!");
-            directory = QString();
-            return;
-        }//_if
-    }
+    if (!RequestProjectDirectoryFromUser()) return; // if the path was chosen incorrectly -> returns.
 
     //Read in the mesh
     QString path = directory + mitk::IOUtil::GetDirectorySeparator() + "segmentation.vtk";
@@ -1941,4 +1807,27 @@ void AtrialScarView::Reset(bool allItems) {
     directory.clear();
     m_Controls.button_z_1->setText("Select Landmarks");
     this->GetSite()->GetPage()->ResetPerspective();
+}
+
+// helper functions
+bool AtrialScarView::RequestProjectDirectoryFromUser(){
+    bool succesfulAssignment = true;
+    //Ask the user for a dir to store data
+    if (directory.isEmpty()) {
+		MITK_INFO << "Directory is empty. Requesting user for directory.";
+        directory = QFileDialog::getExistingDirectory(
+                    NULL, "Open Project Directory", mitk::IOUtil::GetProgramPath().c_str(),
+                    QFileDialog::ShowDirsOnly|QFileDialog::DontUseNativeDialog);
+        MITK_INFO << ("Directory selected:" + directory).toStdString();
+        if (directory.isEmpty() || directory.simplified().contains(" ")) {
+            MITK_WARN << "Please select a project directory with no spaces in the path!";
+            QMessageBox::warning(NULL, "Attention", "Please select a project directory with no spaces in the path!");
+            directory = QString();
+            bool succesfulAssignment = false;
+        }//_if
+    } else {
+        MITK_INFO << ("Project directory already set: " + directory).toStdString();
+    }
+
+    return succesfulAssignment;
 }

--- a/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarView.cpp
@@ -833,9 +833,9 @@ void AtrialScarView::SegmentIMGS() {
                 NULL, "Question", "Do you have a segmentation to load?", QMessageBox::Yes, QMessageBox::No);
 
     if (reply1 == QMessageBox::Yes) {
-
-        QString path = QFileDialog::getOpenFileName(
-                    NULL, "Open Segmentation file", mitk::IOUtil::GetProgramPath().c_str(), QmitkIOUtil::GetFileOpenFilterString());
+        std::string searchFolder = directory.isEmpty() ? mitk::IOUtil::GetProgramPath() : directory.toStdString();
+        QString path = QFileDialog::getOpenFileName(NULL, "Open Segmentation file",
+                        searchFolder.c_str(), QmitkIOUtil::GetFileOpenFilterString());
         if (path.isEmpty()) return;
         mitk::IOUtil::Load(path.toStdString(), *this->GetDataStorage());
         mitk::RenderingManager::GetInstance()->InitializeViewsByBoundingObjects(this->GetDataStorage());

--- a/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarView.h
+++ b/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarView.h
@@ -99,6 +99,9 @@ private:
     void AutomaticAnalysis();
     void Reset(bool allItems);
 
+    // helper functions
+    bool RequestProjectDirectoryFromUser();
+
     QString fileName;
     QString directory;
     QString debugSCARname;

--- a/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarView.h
+++ b/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarView.h
@@ -105,8 +105,10 @@ private:
     QString fileName;
     QString directory;
     QString debugSCARname;
+    QString alternativeNiftiFolder;
     std::unique_ptr<CemrgScar3D> scar;
     bool _useDockerInPlugin = true; // change to FALSE to use MIRTK static libraries
+    bool _usingAlternativeDicomReader;
 };
 
 #endif // AtrialScarView_h

--- a/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/ScarCalculationsView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/ScarCalculationsView.cpp
@@ -57,7 +57,6 @@ PURPOSE.  See the above copyright notices for more information.
 #include <vtkPointLocator.h>
 #include <vtkTextActor.h>
 #include <vtkTextProperty.h>
-#include <vtkDecimatePro.h>
 #include <vtkGenericOpenGLRenderWindow.h>
 #include <vtkCellDataToPointData.h>
 #include <vtkLookupTable.h>

--- a/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/ScarCalculationsView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/ScarCalculationsView.cpp
@@ -1095,7 +1095,7 @@ void ScarCalculationsView::TransformMeshesForComparison() {
     QString sourcename = outpath + "MaxScarPost.vtk";
     QString targetname = outpath + "MaxScarPre.vtk";
     QString alignedname = outpath + "MaxScarPost_Aligned.vtk";
-    QString testTX = outpath + "docker.dof";
+    QString testTX = outpath + "translation.dof";
     this->BusyCursorOn();
     std::unique_ptr<CemrgCommandLine> cmd(new CemrgCommandLine());
     cmd->ExecuteSimpleTranslation(directory, sourcename, targetname, testTX);

--- a/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/ScarCalculationsView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/ScarCalculationsView.cpp
@@ -121,7 +121,7 @@ bool ScarCalculationsView::CheckForRequiredFiles() {
 int ScarCalculationsView::SearchDirectory(QString searchDir){
     MITK_INFO << ("[INFO] Searching files on directory: " + searchDir).toStdString();
     int response = 0;
-    bool debugVar = true;
+    bool debugVar = false;
     bool isPre = searchDir.contains("PRE", Qt::CaseSensitive);
 
     QDirIterator qiter(searchDir, QDirIterator::Subdirectories);

--- a/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/ScarCalculationsView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/ScarCalculationsView.cpp
@@ -635,6 +635,11 @@ void ScarCalculationsView::CtrlPrePostSelection(const QString& text) {
 
 void ScarCalculationsView::EditThreshold() {
 
+    if (m_Controls.fandi_t2_visualise->isEnabled() || m_Controls.fandi_t3_visualise->isEnabled()) {
+        QMessageBox::warning(NULL, "ATTENTION", "Press the Cancel button first.");
+        return;
+    }
+
     MITK_INFO << "Edit threshold button...";
 
     if (m_Controls.combo_thres->count()==0) { // sanity checks

--- a/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/ScarCalculationsView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/ScarCalculationsView.cpp
@@ -105,7 +105,6 @@ void ScarCalculationsView::SetCalculationsPaths(const QString directory) {
 
 bool ScarCalculationsView::CheckForRequiredFiles() {
 
-    int targetfiles = 0;
     QString searchPre = ScarCalculationsView::predir + mitk::IOUtil::GetDirectorySeparator();
     QString searchPost = ScarCalculationsView::postdir + mitk::IOUtil::GetDirectorySeparator();
 

--- a/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/ScarCalculationsView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/ScarCalculationsView.cpp
@@ -287,6 +287,11 @@ void ScarCalculationsView::CreateQtPartControl(QWidget *parent) {
 
         csadv->SetOutputFileName((prodPathOut+outprefix+"encirclement.csv").toStdString());
         csadv->SetOutputPath(prodPathOut.toStdString());
+
+        csadv->SetSurfaceAreaFilename("SurfaceAreaResults.txt");
+        csadv->SetGapsFilename("GapsMeasurementsResults.txt");
+        csadv->SetComparisonFilename("ComparisonResults.txt");
+
         csadv->SetOutputPrefix(outprefix.toStdString());
         csadv->SetFillThreshold(thres);
         csadv->SetInputData(surface->GetVtkPolyData());
@@ -452,8 +457,9 @@ void ScarCalculationsView::BinVisualiser() {
         if (s < min_scalar)
             min_scalar = s;
     }
-    if (max_scalar==3)
+    if (max_scalar==3){
         numlabels = 4;
+    }
 
     vtkSmartPointer<vtkPolyDataMapper> surfMapper = vtkSmartPointer<vtkPolyDataMapper>::New();
     surfMapper->SetInputData(surface->GetVtkPolyData());
@@ -483,6 +489,7 @@ void ScarCalculationsView::BinVisualiser() {
     surfActor->GetProperty()->SetOpacity(1);
 
     renderer->AddActor(surfActor);
+    renderer->AddActor2D(scalarBar);
 }
 
 void ScarCalculationsView::Visualiser() {
@@ -538,6 +545,10 @@ void ScarCalculationsView::Visualiser() {
     scalarBar->GetPositionCoordinate()->SetCoordinateSystemToNormalizedViewport();
     scalarBar->GetPositionCoordinate()->SetValue( 0.9, 0.01 );
     scalarBar->SetNumberOfLabels(5);
+
+    std::string scalarBarTitle = "Raw Signal \n Intensity";
+    scalarBar->SetTitle(scalarBarTitle.c_str());
+    scalarBar->SetVerticalTitleSeparation(15);
 
     surfMapper->SetLookupTable(lut);
     scalarBar->SetLookupTable(lut);
@@ -768,7 +779,6 @@ void ScarCalculationsView::SaveNewThreshold() {
 }
 
 void ScarCalculationsView::CancelThresholdEdit() {
-
     m_Controls.combo_thres->setEnabled(false);
     m_Controls.button_saveth->setEnabled(false);
     m_Controls.button_cancel->setEnabled(false);
@@ -870,6 +880,15 @@ void ScarCalculationsView::PickCallBack() {
 // Button functionalities
 void ScarCalculationsView::DoImageProcessing() {
 
+    if (m_Controls.fandi_t2_visualise->isEnabled() || m_Controls.fandi_t3_visualise->isEnabled()) {
+        QMessageBox::warning(NULL, "ATTENTION", "Press the Cancel button first.");
+        return;
+    }
+    if (m_Controls.button_saveth->isEnabled()) {
+        QMessageBox::warning(NULL, "ATTENTION", "Press the Cancel button or save your threshold first.");
+        return;
+    }
+
     // F&I T1
     MITK_INFO << "[INFO] F&I Task 1. Comparison of Surface Area.";
     csadv->GetSurfaceAreaFromThreshold(thres, maxScalar);
@@ -879,6 +898,15 @@ void ScarCalculationsView::DoImageProcessing() {
 }
 
 void ScarCalculationsView::GapMeasurement() {
+
+    if (m_Controls.fandi_t2_visualise->isEnabled() || m_Controls.fandi_t3_visualise->isEnabled()) {
+        QMessageBox::warning(NULL, "ATTENTION", "Press the Cancel button first.");
+        return;
+    }
+    if (m_Controls.button_saveth->isEnabled()) {
+        QMessageBox::warning(NULL, "ATTENTION", "Press the Cancel button or save your threshold first.");
+        return;
+    }
 
     // F&I T2
     if (pickedSeedIds->GetNumberOfIds()==0) {
@@ -992,6 +1020,15 @@ void ScarCalculationsView::GapMeasurementVisualisation(const QString& text) {
 }
 
 void ScarCalculationsView::BeforeAndAfterComp() {
+
+    if (m_Controls.fandi_t2_visualise->isEnabled() || m_Controls.fandi_t3_visualise->isEnabled()) {
+        QMessageBox::warning(NULL, "ATTENTION", "Press the Cancel button first.");
+        return;
+    }
+    if (m_Controls.button_saveth->isEnabled()) {
+        QMessageBox::warning(NULL, "ATTENTION", "Press the Cancel button or save your threshold first.");
+        return;
+    }
 
     // F&I T3
     MITK_INFO << "[INFO] F&I Task 3. Measurement of scar overlap.\n";

--- a/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/ScarCalculationsView.h
+++ b/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/ScarCalculationsView.h
@@ -70,6 +70,7 @@ public:
     static void SetCalculationsPaths(const QString directory);
     static void GetInputsFromFile();
     static bool CheckForRequiredFiles();
+    static int SearchDirectory(QString searchDir);
     ~ScarCalculationsView();
 
 protected slots:
@@ -128,6 +129,8 @@ private:
     static QString predir;
     static QString postdir;
     static QString advdir;
+    static QString preScarFile;
+    static QString postScarFile;
     int method;
     double value, mean, stdv, thres;
     double maxScalar, minScalar;

--- a/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/ScarCalculationsViewUICorridor.ui
+++ b/Version2.0/Plugins/kcl.cemrgapp.scar/src/internal/ScarCalculationsViewUICorridor.ui
@@ -79,7 +79,7 @@
    <item>
     <widget class="QLineEdit" name="txtbox_thick">
      <property name="placeholderText">
-      <string>Thickness [mm] (default = 5)</string>
+      <string>Thickness (default = 3)</string>
      </property>
     </widget>
    </item>

--- a/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsClipperView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsClipperView.cpp
@@ -258,8 +258,10 @@ void WallThicknessCalculationsClipperView::iniPreSurf() {
 void WallThicknessCalculationsClipperView::CtrLines() {
 
     if (clipper->GetCentreLines().size() == 0 && pickedSeedLabels.size() == 0) {
+
         QMessageBox::warning(NULL, "Attention", "Please maske sure you have selected seeds!");
         return;
+
     } else {
 
         //Retrieve centrelines and labels
@@ -273,8 +275,15 @@ void WallThicknessCalculationsClipperView::CtrLines() {
             pickedSeedLabels.push_back(lb->GetValue(0));
         }//_for
         mitk::ProgressBar::GetInstance()->AddStepsToDo(pickedSeedLabels.size());
-        clipper->ComputeCtrLines(pickedSeedLabels, pickedSeedIds, m_Controls.checkBox->isChecked());
+        bool successful = clipper->ComputeCtrLines(pickedSeedLabels, pickedSeedIds, m_Controls.checkBox->isChecked());
         this->BusyCursorOff();
+
+        //Check for failure
+        if (!successful) {
+            QMessageBox::critical(NULL, "Attention", "Computation of Centrelines Failed!");
+            return;
+        }//_if
+
     }//_if
 
     //Set surface opacity
@@ -317,14 +326,23 @@ void WallThicknessCalculationsClipperView::CtrLines() {
 void WallThicknessCalculationsClipperView::CtrPlanes() {
 
     if (clipper->GetCentreLines().size() == 0 || pickedSeedLabels.size() == 0) {
+
         QMessageBox::warning(NULL, "Attention", "Please maske sure you have computed centre lines!");
         return;
+
     } else {
 
         this->BusyCursorOn();
         mitk::ProgressBar::GetInstance()->AddStepsToDo(pickedSeedLabels.size());
-        clipper->ComputeCtrLinesClippers(pickedSeedLabels);
+        bool successful = clipper->ComputeCtrLinesClippers(pickedSeedLabels);
         this->BusyCursorOff();
+
+        //Check for failure
+        if (!successful) {
+            QMessageBox::critical(NULL, "Attention", "Computation of Clipper Planes Failed!");
+            return;
+        }//_if
+
     }//_if
 
     std::vector<vtkSmartPointer<vtkRegularPolygonSource>> ctrPlanes = clipper->GetCentreLinePolyPlanes();

--- a/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsClipperView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsClipperView.cpp
@@ -213,7 +213,7 @@ void WallThicknessCalculationsClipperView::iniPreSurf() {
                 if (!ok1) iter = 1;
                 if (!ok2) th   = 0.5;
                 if (!ok3) blur = 0;
-                if (!ok4) smth = 0;
+                if (!ok4) smth = 10;
                 if (!ok5) ds   = 0.99;
                 //_if
 

--- a/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsClipperView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsClipperView.cpp
@@ -57,6 +57,8 @@ PURPOSE.  See the above copyright notices for more information.
 #include <vtkDecimatePro.h>
 #include <vtkCleanPolyData.h>
 #include <vtkPolyDataNormals.h>
+#include <vtkWindowedSincPolyDataFilter.h>
+#include <vtkPolyDataConnectivityFilter.h>
 
 //ITK
 #include <itkAddImageFilter.h>
@@ -218,7 +220,7 @@ void WallThicknessCalculationsClipperView::iniPreSurf() {
                 this->BusyCursorOn();
                 path = directory + mitk::IOUtil::GetDirectorySeparator() + "temp.nii";
                 mitk::IOUtil::Save(image, path.toStdString());
-                mitk::ProgressBar::GetInstance()->AddStepsToDo(4);
+                mitk::ProgressBar::GetInstance()->AddStepsToDo(3);
                 std::unique_ptr<CemrgCommandLine> cmd(new CemrgCommandLine());
                 QString output = cmd->ExecuteSurf(directory, path, "close", iter, th, blur, smth);
                 QMessageBox::information(NULL, "Attention", "Command Line Operations Finished!");
@@ -230,9 +232,24 @@ void WallThicknessCalculationsClipperView::iniPreSurf() {
                 deci->SetInputData(shell->GetVtkPolyData());
                 deci->SetTargetReduction(ds);
                 deci->PreserveTopologyOn();
-                deci->Update();      
+                deci->Update();
+                vtkSmartPointer<vtkPolyDataConnectivityFilter> connectivityFilter = vtkSmartPointer<vtkPolyDataConnectivityFilter>::New();
+                connectivityFilter->SetInputConnection(deci->GetOutputPort());
+                connectivityFilter->ColorRegionsOff();
+                connectivityFilter->SetExtractionModeToLargestRegion();
+                connectivityFilter->Update();
+                vtkSmartPointer<vtkWindowedSincPolyDataFilter> smoother = vtkSmartPointer<vtkWindowedSincPolyDataFilter>::New();
+                smoother->SetInputConnection(connectivityFilter->GetOutputPort());
+                smoother->SetNumberOfIterations(30);
+                smoother->BoundarySmoothingOff();
+                smoother->FeatureEdgeSmoothingOff();
+                smoother->SetFeatureAngle(120.0);
+                smoother->SetPassBand(.01);
+                smoother->NonManifoldSmoothingOn();
+                smoother->NormalizeCoordinatesOn();
+                smoother->Update();
                 vtkSmartPointer<vtkCleanPolyData> cleaner = vtkSmartPointer<vtkCleanPolyData>::New();
-                cleaner->SetInputConnection(deci->GetOutputPort());
+                cleaner->SetInputConnection(smoother->GetOutputPort());
                 cleaner->PieceInvariantOn();
                 cleaner->ConvertLinesToPointsOn();
                 cleaner->ConvertStripsToPolysOn();
@@ -282,6 +299,7 @@ void WallThicknessCalculationsClipperView::CtrLines() {
         //Retrieve centrelines and labels
         if (clipper->GetCentreLines().size() != 0)
             QMessageBox::information(NULL, "Attention", "You are using precomputed centrelines!");
+
         this->BusyCursorOn();
         for (unsigned int i=0; i<clipper->GetCentreLines().size(); i++) {
             if (i == 0) pickedSeedLabels.clear();
@@ -289,7 +307,6 @@ void WallThicknessCalculationsClipperView::CtrLines() {
             vtkSmartPointer<vtkIntArray> lb = vtkIntArray::SafeDownCast(pd->GetFieldData()->GetAbstractArray("PickedSeedLabels"));
             pickedSeedLabels.push_back(lb->GetValue(0));
         }//_for
-        mitk::ProgressBar::GetInstance()->AddStepsToDo(pickedSeedLabels.size());
         bool successful = clipper->ComputeCtrLines(pickedSeedLabels, pickedSeedIds, m_Controls.checkBox->isChecked());
         m_Controls.checkBox->setChecked(clipper->GetCentreLinesOrientation());
         this->BusyCursorOff();
@@ -299,7 +316,6 @@ void WallThicknessCalculationsClipperView::CtrLines() {
             QMessageBox::critical(NULL, "Attention", "Computation of Centrelines Failed!");
             return;
         }//_if
-
     }//_if
 
     //Set surface opacity
@@ -349,7 +365,6 @@ void WallThicknessCalculationsClipperView::CtrPlanes() {
     } else {
 
         this->BusyCursorOn();
-        mitk::ProgressBar::GetInstance()->AddStepsToDo(pickedSeedLabels.size());
         bool successful = clipper->ComputeCtrLinesClippers(pickedSeedLabels);
         this->BusyCursorOff();
 
@@ -358,7 +373,6 @@ void WallThicknessCalculationsClipperView::CtrPlanes() {
             QMessageBox::critical(NULL, "Attention", "Computation of Clipper Planes Failed!");
             return;
         }//_if
-
     }//_if
 
     std::vector<vtkSmartPointer<vtkRegularPolygonSource>> ctrPlanes = clipper->GetCentreLinePolyPlanes();
@@ -435,7 +449,6 @@ void WallThicknessCalculationsClipperView::ClipperImage() {
 
                 this->BusyCursorOn();
                 this->GetDataStorage()->Remove(segNode);
-                mitk::ProgressBar::GetInstance()->AddStepsToDo(pickedSeedLabels.size());
                 clipper->ClipVeinsImage(pickedSeedLabels, image, morphAnalysis ? true : false);
                 this->BusyCursorOff();
                 QMessageBox::information(NULL, "Attention", "Segmentation is now clipped!");
@@ -444,7 +457,6 @@ void WallThicknessCalculationsClipperView::ClipperImage() {
                 QMessageBox::warning(NULL, "Attention", "Please select the loaded or created segmentation!");
                 return;
             }//_image
-
         } else {
             QMessageBox::warning(NULL, "Attention", "Please select the loaded or created segmentation!");
             return;

--- a/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsClipperView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsClipperView.cpp
@@ -184,7 +184,7 @@ void WallThicknessCalculationsClipperView::iniPreSurf() {
         if (image) {
 
             //Check seg node name
-            if (segNode->GetName().compare(fileName.left(fileName.length()-4).toStdString()) != 0) {
+            if (segNode->GetName().compare(fileName.left(fileName.lastIndexOf(QChar('.'))).toStdString()) != 0) {
                 QMessageBox::warning(NULL, "Attention", "Please select the loaded or created segmentation!");
                 this->GetSite()->GetPage()->ResetPerspective();
                 return;
@@ -214,7 +214,7 @@ void WallThicknessCalculationsClipperView::iniPreSurf() {
                 if (!ok2) th   = 0.5;
                 if (!ok3) blur = 0;
                 if (!ok4) smth = 10;
-                if (!ok5) ds   = 0.99;
+                if (!ok5) ds   = 0.9;
                 //_if
 
                 this->BusyCursorOn();
@@ -244,7 +244,7 @@ void WallThicknessCalculationsClipperView::iniPreSurf() {
                 smoother->BoundarySmoothingOff();
                 smoother->FeatureEdgeSmoothingOff();
                 smoother->SetFeatureAngle(120.0);
-                smoother->SetPassBand(.01);
+                smoother->SetPassBand(.1);
                 smoother->NonManifoldSmoothingOn();
                 smoother->NormalizeCoordinatesOn();
                 smoother->Update();
@@ -430,7 +430,7 @@ void WallThicknessCalculationsClipperView::ClipperImage() {
 
                 //Check if the right segmentation
                 bool morphAnalysis = false;
-                if (segNode->GetName().compare(fileName.left(fileName.length()-4).toStdString()) == 0) {
+                if (segNode->GetName().compare(fileName.left(fileName.lastIndexOf(QChar('.'))).toStdString()) == 0) {
                     int reply1 = QMessageBox::question(
                                 NULL, "Question", "Are you sure you want to clip the same segmentation used for creating the visualised mesh?",
                                 QMessageBox::Yes, QMessageBox::No);

--- a/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsClipperView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsClipperView.cpp
@@ -291,6 +291,7 @@ void WallThicknessCalculationsClipperView::CtrLines() {
         }//_for
         mitk::ProgressBar::GetInstance()->AddStepsToDo(pickedSeedLabels.size());
         bool successful = clipper->ComputeCtrLines(pickedSeedLabels, pickedSeedIds, m_Controls.checkBox->isChecked());
+        m_Controls.checkBox->setChecked(clipper->GetCentreLinesOrientation());
         this->BusyCursorOff();
 
         //Check for failure

--- a/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsClipperViewLabels.ui
+++ b/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsClipperViewLabels.ui
@@ -10,6 +10,18 @@
     <height>248</height>
    </rect>
   </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>248</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>248</height>
+   </size>
+  </property>
   <property name="windowTitle">
    <string>Set Values</string>
   </property>

--- a/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsView.cpp
@@ -573,7 +573,7 @@ void WallThicknessCalculationsView::MorphologyAnalysis() {
                 if (!ok2) th   = 0.5;
                 if (!ok3) blur = 0;
                 if (!ok4) smth = 10;
-                if (!ok5) ds   = 0.99;
+                if (!ok5) ds   = 0.9;
                 //_if
 
                 this->BusyCursorOn();
@@ -602,7 +602,7 @@ void WallThicknessCalculationsView::MorphologyAnalysis() {
                 smoother1->BoundarySmoothingOff();
                 smoother1->FeatureEdgeSmoothingOff();
                 smoother1->SetFeatureAngle(120.0);
-                smoother1->SetPassBand(.01);
+                smoother1->SetPassBand(.1);
                 smoother1->NonManifoldSmoothingOn();
                 smoother1->NormalizeCoordinatesOn();
                 smoother1->Update();
@@ -646,7 +646,7 @@ void WallThicknessCalculationsView::MorphologyAnalysis() {
                 smoother2->BoundarySmoothingOff();
                 smoother2->FeatureEdgeSmoothingOff();
                 smoother2->SetFeatureAngle(120.0);
-                smoother2->SetPassBand(.01);
+                smoother2->SetPassBand(.1);
                 smoother2->NonManifoldSmoothingOn();
                 smoother2->NormalizeCoordinatesOn();
                 smoother2->Update();

--- a/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsView.cpp
@@ -795,7 +795,7 @@ void WallThicknessCalculationsView::ThicknessCalculator() {
                     if (templatePath.isEmpty()) {
                         QString paramFileName = "param-template.par";
                         QString thicknessCalc = "1";
-                        templatePath = CemrgCommonUtils::m3dlibParamFileGenerator(directory,paramFileName,thicknessCalc);
+                        templatePath = CemrgCommonUtils::M3dlibParamFileGenerator(directory,paramFileName,thicknessCalc);
                     }//_if
 
                     //FileName checks

--- a/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsView.cpp
@@ -182,12 +182,15 @@ void WallThicknessCalculationsView::ConvertNII() {
     //Generic Conversion to nii
     int ctr = 0;
     QString path;
-    bool successfulNitfi;
+    bool successfulNitfi, resampleImage, reorientToRAI;
+    resampleImage = false;
+    reorientToRAI = true;
+
     this->BusyCursorOn();
     mitk::ProgressBar::GetInstance()->AddStepsToDo(nodes.size());
     foreach (mitk::DataNode::Pointer node, nodes) {
         path = directory + mitk::IOUtil::GetDirectorySeparator() + "dcm-" + QString::number(ctr++) + ".nii";
-        successfulNitfi = CemrgCommonUtils::ConvertToNifti(node->GetData(), path);
+        successfulNitfi = CemrgCommonUtils::ConvertToNifti(node->GetData(), path, resampleImage, reorientToRAI);
         if (successfulNitfi) {
             this->GetDataStorage()->Remove(node);
         } else {

--- a/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsView.cpp
@@ -379,8 +379,8 @@ void WallThicknessCalculationsView::SegmentIMGS() {
         mitk::RenderingManager::GetInstance()->InitializeViewsByBoundingObjects(this->GetDataStorage());
 
         //Restore image name
-        char sep = mitk::IOUtil::GetDirectorySeparator();
-        fileName = path.mid(path.lastIndexOf(sep) + 1);
+        QFileInfo fullPathInfo(path);
+        fileName = fullPathInfo.fileName();
 
     } else {
         //Show the plugin

--- a/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsView.cpp
+++ b/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsView.cpp
@@ -180,21 +180,17 @@ void WallThicknessCalculationsView::ConvertNII() {
     //Generic Conversion to nii
     int ctr = 0;
     QString path;
+    bool successfulNitfi;
     this->BusyCursorOn();
     mitk::ProgressBar::GetInstance()->AddStepsToDo(nodes.size());
     foreach (mitk::DataNode::Pointer node, nodes) {
-        mitk::BaseData::Pointer data = node->GetData();
-        if (data) {
-            //Test if this data item is an image
-            mitk::Image::Pointer image = dynamic_cast<mitk::Image*>(data.GetPointer());
-            if (image) {
-                path = directory + mitk::IOUtil::GetDirectorySeparator() + "dcm-" + QString::number(ctr++) + ".nii";
-                mitk::IOUtil::Save(image, path.toStdString());
-                this->GetDataStorage()->Remove(node);
-            } else
-                return;
-        } else
+        path = directory + mitk::IOUtil::GetDirectorySeparator() + "dcm-" + QString::number(ctr++) + ".nii";
+        successfulNitfi = CemrgCommonUtils::ConvertToNifti(node->GetData(), path);
+        if(successfulNitfi){
+            this->GetDataStorage()->Remove(node);
+        } else{
             return;
+        }
         mitk::ProgressBar::GetInstance()->Progress();
     }//_for
     nodes.clear();

--- a/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsViewUIMeshing.ui
+++ b/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsViewUIMeshing.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>222</width>
-    <height>213</height>
+    <height>227</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,7 +19,13 @@
   <property name="minimumSize">
    <size>
     <width>0</width>
-    <height>0</height>
+    <height>227</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>227</height>
    </size>
   </property>
   <property name="windowTitle">

--- a/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsViewUIMeshing.ui
+++ b/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsViewUIMeshing.ui
@@ -75,7 +75,7 @@
       <string/>
      </property>
      <property name="placeholderText">
-      <string>Smooth (default = 0)</string>
+      <string>Smooth (default = 10)</string>
      </property>
     </widget>
    </item>

--- a/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsViewUIThickness.ui
+++ b/Version2.0/Plugins/kcl.cemrgapp.wathca/src/internal/WallThicknessCalculationsViewUIThickness.ui
@@ -7,8 +7,20 @@
     <x>0</x>
     <y>0</y>
     <width>500</width>
-    <height>97</height>
+    <height>103</height>
    </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>103</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>103</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Set Values</string>


### PR DESCRIPTION
This changes addresses issue #10 as well as other minor bugs which had not been logged in. The current state state of the log shows the descriptions of the fixes: 
```
* e9b2e91 (HEAD -> development)  Issue #10: File name handling inconsistencies between windows/unix. Fixed - needs testing.
* b4a70d3 Loading segmentation. Changed default search folder to preset directory.
* 0096c85 Do not dilate MV on automatic segmentation.

* c74fc02 (tag: v2.0, origin/master, origin/development, origin/HEAD) Version 2.0 for CemrgApp Paper
* 6b37f45 release/hotfix: Fixed path assignment error for macOS selection of local libraries.
```