### PR TITLE
Advanced user controls scar

### DIFF
--- a/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgAppCmdTemplate.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgAppCmdTemplate.cpp
@@ -52,11 +52,11 @@ int main(int argc, char* argv[]) {
     // Add arguments. Unless specified otherwise, each argument is optional.
     // See mitkCommandLineParser::addArgument() for more information.
     parser.addArgument(
-        "input", "i", mitkCommandLineParser::InputFile,
+        "input", "i", mitkCommandLineParser::String,
         "Input Image", "Any image format known to MITK.",
         us::Any(), false);
     parser.addArgument(
-        "output", "o", mitkCommandLineParser::OutputFile,
+        "output", "o", mitkCommandLineParser::String,
         "Output file", "Where to save the output.",
         us::Any(), false);
     parser.addArgument(

--- a/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgAreaFromThreshold.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgAreaFromThreshold.cpp
@@ -90,11 +90,11 @@ int main(int argc, char* argv[]) {
     // Add arguments. Unless specified otherwise, each argument is optional.
     // See mitkCommandLineParser::addArgument() for more information.
     // parser.addArgument(
-    //   "input-path", "p", mitkCommandLineParser::InputFile,
+    //   "input-path", "p", mitkCommandLineParser::String,
     //   "Input Directory Path", "Path of directory containing LGE files.",
     //   us::Any(), false);
     parser.addArgument(
-        "input", "i", mitkCommandLineParser::InputFile,
+        "input", "i", mitkCommandLineParser::String,
         "Surface mesh path", "Full path of mesh vtk polydata file.",
         us::Any(), false);
     parser.addArgument(

--- a/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgClippingTool.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgClippingTool.cpp
@@ -92,15 +92,15 @@ int main(int argc, char* argv[]) {
     // Add arguments. Unless specified otherwise, each argument is optional.
     // See mitkCommandLineParser::addArgument() for more information.
     // parser.addArgument(
-    //   "input-path", "p", mitkCommandLineParser::InputFile,
+    //   "input-path", "p", mitkCommandLineParser::String,
     //   "Input Directory Path", "Path of directory containing LGE files.",
     //   us::Any(), false);
     parser.addArgument(
-        "input-vtk", "i", mitkCommandLineParser::InputFile,
+        "input-vtk", "i", mitkCommandLineParser::String,
         "segmentation (vtk) path", "Full path of segmentation.vtk file.",
         us::Any(), false);
     parser.addArgument(
-        "output", "o", mitkCommandLineParser::OutputFile,
+        "output", "o", mitkCommandLineParser::String,
         "Output file", "Where to save the output.",
         us::Any(), false);
     parser.addArgument(

--- a/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgColourSurface.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgColourSurface.cpp
@@ -112,7 +112,7 @@ int main(int argc, char* argv[]) {
     // Add arguments. Unless specified otherwise, each argument is optional.
     // See mitkCommandLineParser::addArgument() for more information.
     parser.addArgument("input-segmentation", "i",
-        mitkCommandLineParser::InputFile,"Input segmentation (.nii)",
+        mitkCommandLineParser::String,"Input segmentation (.nii)",
         "Input segmentation file (commonly output of CEMRGNET)", us::Any(), false
     );
 

--- a/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgFixShellApp.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgFixShellApp.cpp
@@ -85,15 +85,15 @@ int main(int argc, char* argv[]) {
     // Add arguments. Unless specified otherwise, each argument is optional.
     // See mitkCommandLineParser::addArgument() for more information.
     // parser.addArgument(
-    //   "input-path", "p", mitkCommandLineParser::InputFile,
+    //   "input-path", "p", mitkCommandLineParser::String,
     //   "Input Directory Path", "Path of directory containing LGE files.",
     //   us::Any(), false);
     parser.addArgument(
-        "input-lge", "i", mitkCommandLineParser::InputFile,
+        "input-lge", "i", mitkCommandLineParser::String,
         "LGE path", "Full path of LGE.nii file.",
         us::Any(), false);
     parser.addArgument(
-        "output", "o", mitkCommandLineParser::OutputFile,
+        "output", "o", mitkCommandLineParser::String,
         "Output file", "Where to save the output.",
         us::Any(), false);
     parser.addArgument( // optional

--- a/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgIM2INR.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgIM2INR.cpp
@@ -92,11 +92,11 @@ int main(int argc, char* argv[]) {
     // Add arguments. Unless specified otherwise, each argument is optional.
     // See mitkCommandLineParser::addArgument() for more information.
     // parser.addArgument(
-    //   "input-path", "p", mitkCommandLineParser::InputFile,
+    //   "input-path", "p", mitkCommandLineParser::String,
     //   "Input Directory Path", "Path of directory containing LGE files.",
     //   us::Any(), false);
     parser.addArgument(
-        "input", "i", mitkCommandLineParser::InputFile,
+        "input", "i", mitkCommandLineParser::String,
         "Input image", "Full path of image file.",
         us::Any(), false);
     parser.addArgument(

--- a/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgImageConvertFormat.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgImageConvertFormat.cpp
@@ -92,11 +92,11 @@ int main(int argc, char* argv[]) {
     // Add arguments. Unless specified otherwise, each argument is optional.
     // See mitkCommandLineParser::addArgument() for more information.
     // parser.addArgument(
-    //   "input-path", "p", mitkCommandLineParser::InputFile,
+    //   "input-path", "p", mitkCommandLineParser::String,
     //   "Input Directory Path", "Path of directory containing LGE files.",
     //   us::Any(), false);
     parser.addArgument(
-        "input", "i", mitkCommandLineParser::InputFile,
+        "input", "i", mitkCommandLineParser::String,
         "Input image", "Full path of image file.",
         us::Any(), false);
     parser.addArgument(

--- a/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgMorphAnalysis.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgMorphAnalysis.cpp
@@ -57,7 +57,7 @@ int main(int argc, char* argv[]) {
 
     // Add arguments. Unless specified otherwise, each argument is optional.
     parser.addArgument(
-        "directory", "d", mitkCommandLineParser::InputFile,
+        "directory", "d", mitkCommandLineParser::String,
         "Directory path", "Full path of directory",
         us::Any(), false);
 

--- a/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgProjectLgeToVtkMesh.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgProjectLgeToVtkMesh.cpp
@@ -93,15 +93,15 @@ int main(int argc, char* argv[]) {
     // Add arguments. Unless specified otherwise, each argument is optional.
     // See mitkCommandLineParser::addArgument() for more information.
     parser.addArgument(
-        "input-lge", "lge", mitkCommandLineParser::InputFile,
+        "input-lge", "lge", mitkCommandLineParser::String,
         "LGE Image", "Full path to the .nii file with the lge score.",
         us::Any(), false);
     parser.addArgument(
-        "input-surface", "surf", mitkCommandLineParser::InputFile,
+        "input-surface", "surf", mitkCommandLineParser::String,
         "Surface Image", "Full path to the .vtk file with the surface.",
         us::Any(), false);
     parser.addArgument(
-        "output", "o", mitkCommandLineParser::OutputFile,
+        "output", "o", mitkCommandLineParser::String,
         "Output file", "Where to save the output.",
         us::Any(), false);
     parser.addArgument(

--- a/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgProjectionOptions.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgProjectionOptions.cpp
@@ -85,11 +85,11 @@ int main(int argc, char* argv[]) {
     // Add arguments. Unless specified otherwise, each argument is optional.
     // See mitkCommandLineParser::addArgument() for more information.
     // parser.addArgument(
-    //   "input-path", "p", mitkCommandLineParser::InputFile,
+    //   "input-path", "p", mitkCommandLineParser::String,
     //   "Input Directory Path", "Path of directory containing LGE files.",
     //   us::Any(), false);
     parser.addArgument(
-        "input-lge", "i", mitkCommandLineParser::InputFile,
+        "input-lge", "i", mitkCommandLineParser::String,
         "LGE path", "Full path of LGE.nii file.",
         us::Any(), false);
     parser.addArgument( // optional
@@ -101,6 +101,12 @@ int main(int argc, char* argv[]) {
     parser.addArgument( // optional
         "multi-thresholds", "t", mitkCommandLineParser::Bool,
         "Multiple thresholds", "Produce the output for the scar score using multiple thresholds:\n\t  (mean+V*stdev) V = 1:0.1:5\n\t (V*IIR) V = 0.7:0.01:1.61");
+    parser.addArgument( // optional
+        "roi-radius", "radius", mitkCommandLineParser::Bool,
+        "ROI Radius ON", "Whether to create ROI radius");
+    parser.addArgument( // optional
+        "legacy-projection", "old", mitkCommandLineParser::Bool,
+        "Legacy (old) projection algorithm", "Legacy (old) projection algorithm");
     parser.addArgument( // optional
         "verbose", "v", mitkCommandLineParser::Bool,
         "Verbose Output", "Whether to produce verbose output");
@@ -127,6 +133,8 @@ int main(int argc, char* argv[]) {
     auto thresmethod = 2;
     auto singlevoxelprojection = false;
     auto multithreshold = false;
+    auto roi_radius = false;
+    auto legacy_projection = false;
     auto verbose = false;
 
     // Parse, cast and set optional argument
@@ -145,6 +153,16 @@ int main(int argc, char* argv[]) {
         singlevoxelprojection = us::any_cast<bool>(parsedArgs["single-voxel-projection"]);
     }
     std::cout << "single voxel " << singlevoxelprojection << '\n';
+
+    if (parsedArgs.end() != parsedArgs.find("roi-radius")) {
+        roi_radius = us::any_cast<bool>(parsedArgs["roi-radius"]);
+    }
+
+    if (parsedArgs.end() != parsedArgs.find("legacy-projection")) {
+        legacy_projection = us::any_cast<bool>(parsedArgs["legacy-projection"]);
+    }
+
+    roi_radius = roi_radius && !legacy_projection;
 
     if (parsedArgs.end() != parsedArgs.find("verbose")) {
         verbose = us::any_cast<bool>(parsedArgs["verbose"]);
@@ -195,6 +213,8 @@ int main(int argc, char* argv[]) {
         scar->SetMinStep(minStep);
         scar->SetMaxStep(maxStep);
         scar->SetMethodType(methodType);
+        scar->SetRoiLegacyNormals(legacy_projection);
+        scar->SetRoiRadiusOption(roi_radius);
 
         MITK_INFO(singlevoxelprojection) << "Setting Single voxel projection";
         MITK_INFO(!singlevoxelprojection) << "Setting multiple voxels projection";

--- a/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgResampleReorient.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgResampleReorient.cpp
@@ -84,11 +84,11 @@ int main(int argc, char* argv[]) {
 
     // Add arguments. Unless specified otherwise, each argument is optional.
     parser.addArgument(
-        "input", "i", mitkCommandLineParser::InputFile,
+        "input", "i", mitkCommandLineParser::String,
         "NIFTI file path", "Full path of .nii file.",
         us::Any(), false);
     parser.addArgument(
-        "output", "o", mitkCommandLineParser::OutputFile,
+        "output", "o", mitkCommandLineParser::String,
         "Output file", "Where to save the output.",
         us::Any(), false);
     parser.addArgument( // optional

--- a/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgSimpleRegistration.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgSimpleRegistration.cpp
@@ -54,11 +54,11 @@ int main(int argc, char* argv[]) {
     // Add arguments. Unless specified otherwise, each argument is optional.
     // See mitkCommandLineParser::addArgument() for more information.
     parser.addArgument(
-        "reference", "i", mitkCommandLineParser::InputFile,
+        "reference", "i", mitkCommandLineParser::String,
         "Input object (reference)", "Reference for registration. Accepts any image format known to MITK.",
         us::Any(), false);
     parser.addArgument(
-        "otherimage", "j", mitkCommandLineParser::InputFile,
+        "otherimage", "j", mitkCommandLineParser::String,
         "Input object (reference)", "Image to calculate transformation from. Accepts any image format known to MITK.",
         us::Any(), false);
     parser.addArgument( // optional

--- a/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgVentricleSegmRelabel.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgVentricleSegmRelabel.cpp
@@ -111,15 +111,15 @@ int main(int argc, char* argv[]) {
     // Add arguments. Unless specified otherwise, each argument is optional.
     // See mitkCommandLineParser::addArgument() for more information.
     // parser.addArgument(
-    //   "input-path", "p", mitkCommandLineParser::InputFile,
+    //   "input-path", "p", mitkCommandLineParser::String,
     //   "Input Directory Path", "Path of directory containing LGE files.",
     //   us::Any(), false);
     parser.addArgument(
-        "input", "i", mitkCommandLineParser::InputFile,
+        "input", "i", mitkCommandLineParser::String,
         "Input image segmentation", "Full path of segmentation file.",
         us::Any(), false);
     parser.addArgument(
-        "bloodpool", "b", mitkCommandLineParser::InputFile,
+        "bloodpool", "b", mitkCommandLineParser::String,
         "Input image bloodpool seg", "Full path of bloodpool file.",
         us::Any(), false);
     parser.addArgument( // optional

--- a/CemrgApp/Modules/CemrgAppModule/include/CemrgCommonUtils.h
+++ b/CemrgApp/Modules/CemrgAppModule/include/CemrgCommonUtils.h
@@ -57,8 +57,10 @@ public:
 
     // Image Analysis Utils
     static void SetSegmentationEdgesToZero(mitk::Image::Pointer image, QString outPath="");
-    static void Binarise(mitk::Image::Pointer image, float background=0);
     static mitk::Image::Pointer ReturnBinarised(mitk::Image::Pointer image, float background=0);
+
+    static void Binarise(mitk::Image::Pointer image, float background=0);
+    static mitk::Image::Pointer Zeros(mitk::Image::Pointer image);
 
     //Nifti Conversion Utils
     static bool ConvertToNifti(mitk::BaseData::Pointer oneNode, QString path2file, bool resample=false, bool reorient=false);

--- a/CemrgApp/Modules/CemrgAppModule/include/CemrgScar3D.h
+++ b/CemrgApp/Modules/CemrgAppModule/include/CemrgScar3D.h
@@ -36,10 +36,12 @@ PURPOSE.  See the above copyright notices for more information.
 #include <vtkFloatArray.h>
 #include <MitkCemrgAppModuleExports.h>
 #include <QString>
+#include <QDir>
 
 class MITKCEMRGAPPMODULE_EXPORT CemrgScar3D {
 
 public:
+    enum DebugImageType { BACKGROUND=0, CORRIDOR, PROJECTED };
 
     CemrgScar3D();
     mitk::Surface::Pointer Scar3D(std::string directory, mitk::Image::Pointer lgeImage, std::string segname = "segmentation.vtk");
@@ -52,29 +54,28 @@ public:
     void PrintThresholdingResults(QString dir, std::vector<double> values_vector, int threshType, double mean, double stdv, bool printGuide = true);
     void PrintSingleThresholdingResult(QString dir, double value, int threshType, double mean, double stdv);
 
-    double GetMinScalar() const;
-    double GetMaxScalar() const;
-    void SetMinStep(int value);
-    void SetMaxStep(int value);
-    void SetMethodType(int value);
+    inline double GetMinScalar() const { return minScalar; };
+    inline double GetMaxScalar() const { return maxScalar; };
+    inline void SetMinStep(int value) { minStep = value; };
+    inline void SetMaxStep(int value) { maxStep = value; };
+    inline void SetMethodType(int value) { methodType = value; };
     void SetScarSegImage(const mitk::Image::Pointer image);
-    void SetVoxelBasedProjection(bool value);
 
-    inline void SetDebug(bool b){debugging=b;};
-    inline void SetDebugOn(){SetDebug(true);};
-    inline void SetDebugOff(){SetDebug(false);};
+    inline void SetVoxelBasedProjection(bool value){voxelBasedProjection=value;};
+    inline void SetRoiLegacyNormals(bool value){roiLegacyNormals=value;};
+    inline void SetRoiRadiusOption(bool value){roiRadiusOption=value;};
 
 private:
 
     int methodType;
     int minStep, maxStep;
-    bool voxelBasedProjection, debugging;
+    bool voxelBasedProjection, roiLegacyNormals, roiRadiusOption;
     double minScalar, maxScalar;
     vtkSmartPointer<vtkFloatArray> scalars;
 
     typedef itk::Image<short, 3> itkImageType;
     itkImageType::Pointer scarSegImage;
-    itk::Image<short, 3>::Pointer scarDebugLabel;
+    itk::Image<short, 3>::Pointer scarDebugCorridor;
 
     double GetIntensityAlongNormal(
         itkImageType::Pointer scarImage, itkImageType::Pointer visitedImage,

--- a/CemrgApp/Modules/CemrgAppModule/src/CemrgCommonUtils.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/src/CemrgCommonUtils.cpp
@@ -436,6 +436,26 @@ void CemrgCommonUtils::SetSegmentationEdgesToZero(mitk::Image::Pointer image, QS
     }
 }
 
+ mitk::Image::Pointer CemrgCommonUtils::Zeros(mitk::Image::Pointer image){
+    using ImageType = itk::Image<short,3>;
+    
+    ImageType::Pointer outputImg = ImageType::New();
+    mitk::CastToItkImage(image->Clone(), outputImg);
+
+    using IteratorType = itk::ImageRegionIterator<ImageType>;
+    IteratorType imIter(outputImg, outputImg->GetLargestPossibleRegion());
+    imIter.GoToBegin();
+    while(!imIter.IsAtEnd()){
+        imIter.Set(0);
+        ++imIter;
+    }
+    
+    mitk::Image::Pointer outim = mitk::Image::New();
+    mitk::CastToMitkImage(outputImg, outim);
+    
+    return outim;
+ }
+
 void CemrgCommonUtils::RoundPixelValues(QString pathToImage, QString outputPath) {
     QFileInfo fi(pathToImage);
     if (fi.exists()) {

--- a/CemrgApp/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarView.cpp
+++ b/CemrgApp/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarView.cpp
@@ -1431,11 +1431,14 @@ void AtrialScarView::ScarMap() {
                 if (dialogCode == QDialog::Accepted) {
 
                     bool ok1, ok2;
-                    int minStep = m_UIScar.lineEdit_1->text().toInt(&ok1);
-                    int maxStep = m_UIScar.lineEdit_2->text().toInt(&ok2);
+                    int minStep = m_UIScar.line_roi_minStep->text().toInt(&ok1);
+                    int maxStep = m_UIScar.line_roi_maxStep->text().toInt(&ok2);
                     int methodType = m_UIScar.radioButton_1->isChecked() ? 2 : 1;
                     QString meType = m_UIScar.radioButton_1->isChecked() ? "Max" : "Mean";
-                    bool voxelBasedProjection = m_UIScar.checkBox->isChecked();
+                    
+                    bool voxelBasedProjection = m_UIScar.check_roi_voxelBased->isChecked();
+                    bool UseRoiLegacyNormals = m_UIScar.check_roi_legacyNormals->isChecked();
+                    bool UseRoiRadius = m_UIScar.check_roi_radius->isChecked();
 
                     //Set default values
                     if (!ok1 || !ok2)
@@ -1444,6 +1447,19 @@ void AtrialScarView::ScarMap() {
                     if (!ok2) maxStep = 3;
                     //_if
 
+                    std::string msg;
+                    if (UseRoiLegacyNormals){
+                        msg = "Using an old version of the normals algorithm. Setting ROI radius option to ON.";
+                        UseRoiRadius = true;
+                        QMessageBox::warning(NULL, "Attention", msg.c_str());
+                        MITK_WARN << msg; 
+                    }
+
+                    if (!UseRoiRadius){
+                        msg = "The volume of the projection ROI is reduced and might cause a problem with scar calculation.";
+                        QMessageBox::warning(NULL, " Attention ", msg.c_str());
+                        MITK_WARN << msg;
+                    }
                     /*
                      * Producibility Test
                      **/
@@ -1465,6 +1481,9 @@ void AtrialScarView::ScarMap() {
                     scar->SetMaxStep(maxStep);
                     scar->SetMethodType(methodType);
                     scar->SetVoxelBasedProjection(voxelBasedProjection);
+                    scar->SetRoiLegacyNormals(UseRoiLegacyNormals);
+                    scar->SetRoiRadiusOption(UseRoiRadius);
+
                     mitk::Image::Pointer scarSegImg;
                     try {
                         QString path = directory + "/" + fileName;

--- a/CemrgApp/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarViewUIScar.ui
+++ b/CemrgApp/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarViewUIScar.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>223</width>
-    <height>239</height>
+    <width>257</width>
+    <height>341</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -25,7 +25,7 @@
   <property name="maximumSize">
    <size>
     <width>16777215</width>
-    <height>239</height>
+    <height>512</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -70,7 +70,20 @@
     </widget>
    </item>
    <item>
-    <widget class="QLineEdit" name="lineEdit_1">
+    <widget class="QLabel" name="label_2">
+     <property name="styleSheet">
+      <string notr="true">QLabel { color: rgb(255, 0, 0) }</string>
+     </property>
+     <property name="text">
+      <string>Projection ROI Parameters</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="line_roi_minStep">
      <property name="text">
       <string/>
      </property>
@@ -80,9 +93,42 @@
     </widget>
    </item>
    <item>
-    <widget class="QLineEdit" name="lineEdit_2">
+    <widget class="QLineEdit" name="line_roi_maxStep">
      <property name="placeholderText">
       <string>Max Step (default = 3)</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="check_roi_voxelBased">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Changes the intensity's projection method. Resulting in unsmoothed and less fibrotic regions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Voxel Based Projection</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="check_roi_radius">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;body&gt;&lt;p&gt;Use or not the standard region of interest radius. Default is ON&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>ROI Radius</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="check_roi_legacyNormals">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;body&gt;&lt;p&gt;Uses old algorithm to project and calculate scar shell normals.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Legacy Projection Algorithm</string>
      </property>
     </widget>
    </item>
@@ -90,16 +136,6 @@
     <widget class="Line" name="line_2">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="checkBox">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Changes the intensity's projection method. Resulting in unsmoothed and less fibrotic regions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Voxel Based Projection</string>
      </property>
     </widget>
    </item>

--- a/CemrgApp/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarViewUIcemrgnet.ui
+++ b/CemrgApp/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarViewUIcemrgnet.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>480</width>
-    <height>480</height>
+    <width>512</width>
+    <height>512</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -18,8 +18,8 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>480</width>
-    <height>480</height>
+    <width>512</width>
+    <height>512</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -307,6 +307,32 @@
    </property>
    <property name="text">
     <string>Voxel-based method</string>
+   </property>
+  </widget>
+  <widget class="QCheckBox" name="checkBox">
+   <property name="geometry">
+    <rect>
+     <x>180</x>
+     <y>220</y>
+     <width>81</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>ROI Radius</string>
+   </property>
+  </widget>
+  <widget class="QCheckBox" name="checkBox_2">
+   <property name="geometry">
+    <rect>
+     <x>280</x>
+     <y>220</y>
+     <width>161</width>
+     <height>21</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Legacy Projection Algorithm</string>
    </property>
   </widget>
  </widget>


### PR DESCRIPTION
User is able to toggle these new parameters in projection

    Voxel-based projection (already there)
    ROI radius
    Choose to use old algorithm - new one calculates correct normal orientations 

There is a new debug scar image which shows the corridor and the voxels selected