### PR TITLE
`mitkCommandLineParser`: Replace `InputFile` and `OutputFile` with `String`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
 
 
   Build-Linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: [Variables]
     steps:
     - name: Download precompiled Build folder
@@ -216,7 +216,7 @@ jobs:
 
 
   Build-macOS:
-    runs-on: macos-10.15
+    runs-on: macos-12
     needs: [Variables]
     steps:
     - name: Download precompiled Build folder

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   Test-n-Coverage:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Download precompiled Build folder
       run: |

--- a/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgAppCmdTemplate.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgAppCmdTemplate.cpp
@@ -52,11 +52,11 @@ int main(int argc, char* argv[]) {
     // Add arguments. Unless specified otherwise, each argument is optional.
     // See mitkCommandLineParser::addArgument() for more information.
     parser.addArgument(
-        "input", "i", mitkCommandLineParser::InputFile,
+        "input", "i", mitkCommandLineParser::String,
         "Input Image", "Any image format known to MITK.",
         us::Any(), false);
     parser.addArgument(
-        "output", "o", mitkCommandLineParser::OutputFile,
+        "output", "o", mitkCommandLineParser::String,
         "Output file", "Where to save the output.",
         us::Any(), false);
     parser.addArgument(

--- a/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgAreaFromThreshold.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgAreaFromThreshold.cpp
@@ -90,11 +90,11 @@ int main(int argc, char* argv[]) {
     // Add arguments. Unless specified otherwise, each argument is optional.
     // See mitkCommandLineParser::addArgument() for more information.
     // parser.addArgument(
-    //   "input-path", "p", mitkCommandLineParser::InputFile,
+    //   "input-path", "p", mitkCommandLineParser::String,
     //   "Input Directory Path", "Path of directory containing LGE files.",
     //   us::Any(), false);
     parser.addArgument(
-        "input", "i", mitkCommandLineParser::InputFile,
+        "input", "i", mitkCommandLineParser::String,
         "Surface mesh path", "Full path of mesh vtk polydata file.",
         us::Any(), false);
     parser.addArgument(

--- a/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgClippingTool.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgClippingTool.cpp
@@ -92,15 +92,15 @@ int main(int argc, char* argv[]) {
     // Add arguments. Unless specified otherwise, each argument is optional.
     // See mitkCommandLineParser::addArgument() for more information.
     // parser.addArgument(
-    //   "input-path", "p", mitkCommandLineParser::InputFile,
+    //   "input-path", "p", mitkCommandLineParser::String,
     //   "Input Directory Path", "Path of directory containing LGE files.",
     //   us::Any(), false);
     parser.addArgument(
-        "input-vtk", "i", mitkCommandLineParser::InputFile,
+        "input-vtk", "i", mitkCommandLineParser::String,
         "segmentation (vtk) path", "Full path of segmentation.vtk file.",
         us::Any(), false);
     parser.addArgument(
-        "output", "o", mitkCommandLineParser::OutputFile,
+        "output", "o", mitkCommandLineParser::String,
         "Output file", "Where to save the output.",
         us::Any(), false);
     parser.addArgument(

--- a/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgColourSurface.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgColourSurface.cpp
@@ -112,7 +112,7 @@ int main(int argc, char* argv[]) {
     // Add arguments. Unless specified otherwise, each argument is optional.
     // See mitkCommandLineParser::addArgument() for more information.
     parser.addArgument("input-segmentation", "i",
-        mitkCommandLineParser::InputFile,"Input segmentation (.nii)",
+        mitkCommandLineParser::String,"Input segmentation (.nii)",
         "Input segmentation file (commonly output of CEMRGNET)", us::Any(), false
     );
 

--- a/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgFixShellApp.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgFixShellApp.cpp
@@ -85,15 +85,15 @@ int main(int argc, char* argv[]) {
     // Add arguments. Unless specified otherwise, each argument is optional.
     // See mitkCommandLineParser::addArgument() for more information.
     // parser.addArgument(
-    //   "input-path", "p", mitkCommandLineParser::InputFile,
+    //   "input-path", "p", mitkCommandLineParser::String,
     //   "Input Directory Path", "Path of directory containing LGE files.",
     //   us::Any(), false);
     parser.addArgument(
-        "input-lge", "i", mitkCommandLineParser::InputFile,
+        "input-lge", "i", mitkCommandLineParser::String,
         "LGE path", "Full path of LGE.nii file.",
         us::Any(), false);
     parser.addArgument(
-        "output", "o", mitkCommandLineParser::OutputFile,
+        "output", "o", mitkCommandLineParser::String,
         "Output file", "Where to save the output.",
         us::Any(), false);
     parser.addArgument( // optional

--- a/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgIM2INR.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgIM2INR.cpp
@@ -92,11 +92,11 @@ int main(int argc, char* argv[]) {
     // Add arguments. Unless specified otherwise, each argument is optional.
     // See mitkCommandLineParser::addArgument() for more information.
     // parser.addArgument(
-    //   "input-path", "p", mitkCommandLineParser::InputFile,
+    //   "input-path", "p", mitkCommandLineParser::String,
     //   "Input Directory Path", "Path of directory containing LGE files.",
     //   us::Any(), false);
     parser.addArgument(
-        "input", "i", mitkCommandLineParser::InputFile,
+        "input", "i", mitkCommandLineParser::String,
         "Input image", "Full path of image file.",
         us::Any(), false);
     parser.addArgument(

--- a/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgImageConvertFormat.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgImageConvertFormat.cpp
@@ -92,11 +92,11 @@ int main(int argc, char* argv[]) {
     // Add arguments. Unless specified otherwise, each argument is optional.
     // See mitkCommandLineParser::addArgument() for more information.
     // parser.addArgument(
-    //   "input-path", "p", mitkCommandLineParser::InputFile,
+    //   "input-path", "p", mitkCommandLineParser::String,
     //   "Input Directory Path", "Path of directory containing LGE files.",
     //   us::Any(), false);
     parser.addArgument(
-        "input", "i", mitkCommandLineParser::InputFile,
+        "input", "i", mitkCommandLineParser::String,
         "Input image", "Full path of image file.",
         us::Any(), false);
     parser.addArgument(

--- a/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgMorphAnalysis.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgMorphAnalysis.cpp
@@ -57,7 +57,7 @@ int main(int argc, char* argv[]) {
 
     // Add arguments. Unless specified otherwise, each argument is optional.
     parser.addArgument(
-        "directory", "d", mitkCommandLineParser::InputFile,
+        "directory", "d", mitkCommandLineParser::String,
         "Directory path", "Full path of directory",
         us::Any(), false);
 

--- a/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgProjectLgeToVtkMesh.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgProjectLgeToVtkMesh.cpp
@@ -93,15 +93,15 @@ int main(int argc, char* argv[]) {
     // Add arguments. Unless specified otherwise, each argument is optional.
     // See mitkCommandLineParser::addArgument() for more information.
     parser.addArgument(
-        "input-lge", "lge", mitkCommandLineParser::InputFile,
+        "input-lge", "lge", mitkCommandLineParser::String,
         "LGE Image", "Full path to the .nii file with the lge score.",
         us::Any(), false);
     parser.addArgument(
-        "input-surface", "surf", mitkCommandLineParser::InputFile,
+        "input-surface", "surf", mitkCommandLineParser::String,
         "Surface Image", "Full path to the .vtk file with the surface.",
         us::Any(), false);
     parser.addArgument(
-        "output", "o", mitkCommandLineParser::OutputFile,
+        "output", "o", mitkCommandLineParser::String,
         "Output file", "Where to save the output.",
         us::Any(), false);
     parser.addArgument(

--- a/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgProjectionOptions.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgProjectionOptions.cpp
@@ -85,11 +85,11 @@ int main(int argc, char* argv[]) {
     // Add arguments. Unless specified otherwise, each argument is optional.
     // See mitkCommandLineParser::addArgument() for more information.
     // parser.addArgument(
-    //   "input-path", "p", mitkCommandLineParser::InputFile,
+    //   "input-path", "p", mitkCommandLineParser::String,
     //   "Input Directory Path", "Path of directory containing LGE files.",
     //   us::Any(), false);
     parser.addArgument(
-        "input-lge", "i", mitkCommandLineParser::InputFile,
+        "input-lge", "i", mitkCommandLineParser::String,
         "LGE path", "Full path of LGE.nii file.",
         us::Any(), false);
     parser.addArgument( // optional

--- a/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgResampleReorient.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgResampleReorient.cpp
@@ -84,11 +84,11 @@ int main(int argc, char* argv[]) {
 
     // Add arguments. Unless specified otherwise, each argument is optional.
     parser.addArgument(
-        "input", "i", mitkCommandLineParser::InputFile,
+        "input", "i", mitkCommandLineParser::String,
         "NIFTI file path", "Full path of .nii file.",
         us::Any(), false);
     parser.addArgument(
-        "output", "o", mitkCommandLineParser::OutputFile,
+        "output", "o", mitkCommandLineParser::String,
         "Output file", "Where to save the output.",
         us::Any(), false);
     parser.addArgument( // optional

--- a/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgSimpleRegistration.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgSimpleRegistration.cpp
@@ -54,11 +54,11 @@ int main(int argc, char* argv[]) {
     // Add arguments. Unless specified otherwise, each argument is optional.
     // See mitkCommandLineParser::addArgument() for more information.
     parser.addArgument(
-        "reference", "i", mitkCommandLineParser::InputFile,
+        "reference", "i", mitkCommandLineParser::String,
         "Input object (reference)", "Reference for registration. Accepts any image format known to MITK.",
         us::Any(), false);
     parser.addArgument(
-        "otherimage", "j", mitkCommandLineParser::InputFile,
+        "otherimage", "j", mitkCommandLineParser::String,
         "Input object (reference)", "Image to calculate transformation from. Accepts any image format known to MITK.",
         us::Any(), false);
     parser.addArgument( // optional

--- a/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgVentricleSegmRelabel.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/cmdapps/CemrgVentricleSegmRelabel.cpp
@@ -111,15 +111,15 @@ int main(int argc, char* argv[]) {
     // Add arguments. Unless specified otherwise, each argument is optional.
     // See mitkCommandLineParser::addArgument() for more information.
     // parser.addArgument(
-    //   "input-path", "p", mitkCommandLineParser::InputFile,
+    //   "input-path", "p", mitkCommandLineParser::String,
     //   "Input Directory Path", "Path of directory containing LGE files.",
     //   us::Any(), false);
     parser.addArgument(
-        "input", "i", mitkCommandLineParser::InputFile,
+        "input", "i", mitkCommandLineParser::String,
         "Input image segmentation", "Full path of segmentation file.",
         us::Any(), false);
     parser.addArgument(
-        "bloodpool", "b", mitkCommandLineParser::InputFile,
+        "bloodpool", "b", mitkCommandLineParser::String,
         "Input image bloodpool seg", "Full path of bloodpool file.",
         us::Any(), false);
     parser.addArgument( // optional


### PR DESCRIPTION
Fixes compilation errors on both Linux and macOS, as discussed on Slack.