### PR TITLE
Add check for new SkipEmptyParts function

### DIFF
--- a/CemrgApp/Plugins/kcl.cemrgapp.atrialfibres/src/internal/AtrialFibresView.cpp
+++ b/CemrgApp/Plugins/kcl.cemrgapp.atrialfibres/src/internal/AtrialFibresView.cpp
@@ -2103,7 +2103,11 @@ bool AtrialFibresView::GetUserScarProjectionInputs(){
             MITK_INFO << "[UI] Creating list of thresholds";
             separated_thresh_list.removeLast();
             separated_thresh_list.removeLast();
-            separated_thresh_list = thresh_list.split(",", Qt::SkipEmptyParts);
+            #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+                separated_thresh_list = thresh_list.split(",", Qt::SkipEmptyParts);
+            #else
+                separated_thresh_list = thresh_list.split(",", QString::SkipEmptyParts);
+            #endif
             int listspaces = separated_thresh_list.removeAll(" ");
             int listduplicates = separated_thresh_list.removeDuplicates();
             std::cout << "Spaces in list: " << listspaces << " Duplicates in list: " << listduplicates << '\n';

--- a/CemrgApp/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarView.cpp
+++ b/CemrgApp/Plugins/kcl.cemrgapp.scar/src/internal/AtrialScarView.cpp
@@ -420,7 +420,11 @@ void AtrialScarView::AutomaticAnalysis() {
             MITK_INFO << "[UI] Creating list of thresholds";
             separated_thresh_list.removeLast();
             separated_thresh_list.removeLast();
-            separated_thresh_list = thresh_list.split(",", Qt::SkipEmptyParts);
+            #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+                separated_thresh_list = thresh_list.split(",", Qt::SkipEmptyParts);
+            #else
+                separated_thresh_list = thresh_list.split(",", QString::SkipEmptyParts);
+            #endif
             int listspaces = separated_thresh_list.removeAll(" ");
             int listduplicates = separated_thresh_list.removeDuplicates();
             separated_thresh_list.sort();


### PR DESCRIPTION
The `Qt::SkipEmptyParts` enum specifies how `split()` functions should behave with respect to empty strings. It was updated in QT 5.14, changing from `QString::SkipEmptyParts` to `Qt::SkipEmptyParts`.

This PR adds checks where `Qt::SkipEmptyParts` is used, in order to fall back to the older `QString::SkipEmptyParts` for older QT versions. Our regularly used versions are currently 5.15 on macOS and 5.12 on Linux (the latest available 5.x version which is easy to install).