### PR TITLE
Compatibility with Windows Visual Studio 2022

### DIFF
--- a/CemrgApp/Modules/CemrgAppModule/include/CemrgAtrialTools.h
+++ b/CemrgApp/Modules/CemrgAppModule/include/CemrgAtrialTools.h
@@ -90,7 +90,7 @@ class MITKCEMRGAPPMODULE_EXPORT CemrgAtrialTools {
 public:
     CemrgAtrialTools();
     void SetDefaultSegmentationTags();
-    ImageType::Pointer LoadImage(QString imagePath, bool binarise=false);
+    ImageType::Pointer CemrgLoadImage(QString imagePath, bool binarise = false);
     ShortImageType::Pointer LoadShortImage(QString imagePath);
 
     inline void SetDebugMode(bool s2d){debugSteps=s2d; debugMessages=s2d;};

--- a/CemrgApp/Modules/CemrgAppModule/src/CemrgAtrialTools.cpp
+++ b/CemrgApp/Modules/CemrgAppModule/src/CemrgAtrialTools.cpp
@@ -125,7 +125,7 @@ ShortImageType::Pointer LoadShortImage(QString imagePath){
     return itkImage;
 }
 
-ImageType::Pointer CemrgAtrialTools::LoadImage(QString imagePath, bool binarise){
+ImageType::Pointer CemrgAtrialTools::CemrgLoadImage(QString imagePath, bool binarise){
     mitk::Image::Pointer mitkImage = mitk::IOUtil::Load<mitk::Image>(imagePath.toStdString());
     ImageType::Pointer itkImage = ImageType::New();
     mitk::CastToItkImage(mitkImage, itkImage);
@@ -177,9 +177,9 @@ void CemrgAtrialTools::AdjustSegmentationLabelToImage(QString segImPath, QString
 
 void CemrgAtrialTools::ResampleSegmentationLabelToImage(QString segImPath, QString imPath, QString outImPath){
     MITK_INFO(debugMessages) << ("[ResampleSegmentationLabelToImage] Loading " + segImPath).toStdString();
-    ImageType::Pointer segItk = LoadImage(segImPath);
+    ImageType::Pointer segItk = CemrgLoadImage(segImPath);
     MITK_INFO(debugMessages) << ("[ResampleSegmentationLabelToImage] Loading " + imPath).toStdString();
-    ImageType::Pointer im = LoadImage(imPath);
+    ImageType::Pointer im = CemrgLoadImage(imPath);
 
     itk::ResampleImageFilter<ImageType, ImageType>::Pointer resampleFilter;
     resampleFilter = itk::ResampleImageFilter<ImageType, ImageType>::New();
@@ -199,7 +199,7 @@ void CemrgAtrialTools::ResampleSegmentationLabelToImage(QString segImPath, QStri
 
 ImageType::Pointer CemrgAtrialTools::RemoveNoiseFromAutomaticSegmentation(QString dir, QString segName){
     QString inputPath = dir + "/" + segName;
-    ImageType::Pointer orgSegImage = LoadImage(inputPath);
+    ImageType::Pointer orgSegImage = CemrgLoadImage(inputPath);
 
     MITK_INFO << "Extracting clean segmentation.";
     ConnectedComponentImageFilterType::Pointer conn1 = ConnectedComponentImageFilterType::New();
@@ -242,7 +242,7 @@ void CemrgAtrialTools::QuickBinarise(ImageType::Pointer imToBin){
 
 ImageType::Pointer CemrgAtrialTools::CleanAutomaticSegmentation(QString dir, QString segName, QString cleanName){
     QString inputPath = dir + "/" + segName;
-    ImageType::Pointer orgSegImage = LoadImage(inputPath);
+    ImageType::Pointer orgSegImage = CemrgLoadImage(inputPath);
     ImageType::Pointer atriumCoarse = RemoveNoiseFromAutomaticSegmentation(dir, segName);
 
     if(!cleanName.isEmpty()){

--- a/CemrgApp/Plugins/kcl.cemrgapp.atrialfibres/src/internal/AtrialFibresView.cpp
+++ b/CemrgApp/Plugins/kcl.cemrgapp.atrialfibres/src/internal/AtrialFibresView.cpp
@@ -581,7 +581,7 @@ void AtrialFibresView::SegmentIMGS() {
                 }
             }
 
-            ImageType::Pointer segImage = atrium->LoadImage(path);
+            ImageType::Pointer segImage = atrium->CemrgLoadImage(path);
             path = UserIncludeLgeAnalysis(path, segImage);
 
             mitk::Image::Pointer im = mitk::ImportItkImage(segImage);
@@ -705,7 +705,7 @@ void AtrialFibresView::CreateLabelledMesh(){
 
     QString prodPath =  directory + "/";
 
-    ImageType::Pointer pveins = atrium->LoadImage(prodPath+"PVeinsLabelled.nii");
+    ImageType::Pointer pveins = atrium->CemrgLoadImage(prodPath+"PVeinsLabelled.nii");
     if(!tagName.contains("Labelled")){
         std::string msg = "Changing working name from " + tagName.toStdString() + " to 'Labelled'";
         QMessageBox::information(NULL, "Attention", msg.c_str());
@@ -1554,7 +1554,7 @@ void AtrialFibresView::ScarProjection(){
         MITK_INFO << "[SCAR_PROJECTION][5] Thresholding";
         double mean = 0.0, stdv = 0.0;
         bool binarise=true;
-        ImageType::Pointer segITK = atrium->LoadImage(segPath, binarise);
+        ImageType::Pointer segITK = atrium->CemrgLoadImage(segPath, binarise);
         mitk::IOUtil::Save(atrium->ImErode(segITK), Path("roi.nii").toStdString());
 
         atrium->ResampleSegmentationLabelToImage(Path("roi.nii"), lgePath);
@@ -2340,7 +2340,7 @@ QString AtrialFibresView::UserIncludeLgeAnalysis(QString segPath, ImageType::Poi
         cmd->ExecuteRegistration(directory, lgePath, mraPath); // rigid.dof is the default name
         cmd->ExecuteTransformation(directory, segPath, segRegPath);
 
-        segImage = atrium->LoadImage(segRegPath);
+        segImage = atrium->CemrgLoadImage(segRegPath);
 
         resultString = segRegPath;
         tagName += "-reg";


### PR DESCRIPTION
To make this build work, apart from the changes in the code, which are few, one needs to do the following: 
+ Specify manually the `ITK_USE_FILE` in the VMTK/CMakeLists.txt file (See specification below)
+ Comment in `vtkVmtk/Segmentation/CMakeLists.txt` the building of `vtkVmtkMedialCurve...cxx`, it is not needed.

Set `ITK_USE_FILE`
```cmake!
  if ( NOT ITK_FOUND )
  message( STATUS "ITK not found. Please set ITK_DIR." )
    find_package( ITK REQUIRED )
    include( ${ITK_USE_FILE} )
```

And modify it to your include file, like 
```cmake!
  if ( NOT ITK_FOUND )
  message( STATUS "ITK not found. Please set ITK_DIR." )
    find_package( ITK REQUIRED )
    include( "$CEMRG_BUILD/ep/src/ITK/CMake/UseITK.cmake")
```